### PR TITLE
Support dynamic timeframes

### DIFF
--- a/TF_CTX/config_manager.mqh
+++ b/TF_CTX/config_manager.mqh
@@ -274,8 +274,11 @@ bool CConfigManager::LoadConfigFromFile(string file_path)
 bool CConfigManager::CreateContexts()
 {
     Print("Criando contextos a partir da configuração JSON...");
-    
-    string timeframes[] = {"D1", "H4", "H1", "M30", "M15", "M5", "M1"};
+
+    // Itera todos os símbolos configurados e, para cada um,
+    // percorre dinamicamente as chaves de timeframe existentes
+    // no nó do JSON. Isso permite adicionar novos timeframes ao
+    // arquivo de configuração sem modificar o código fonte.
 
     for (int s = 0; s < ArraySize(m_symbols); s++)
     {
@@ -291,11 +294,11 @@ bool CConfigManager::CreateContexts()
         
         Print("Configuração encontrada para símbolo: ", symbol, " com ", symbol_config.Size(), " timeframes");
 
-        for (int t = 0; t < ArraySize(timeframes); t++)
+        for (int t = 0; t < symbol_config.Size(); t++)
         {
-            string tf_str = timeframes[t];
-            Print("Verificando timeframe: ", tf_str);
-            
+            string tf_str = symbol_config.children[t].key;
+            Print("Processando timeframe: ", tf_str);
+
             CJAVal *tf_config = symbol_config[tf_str];
 
             if (tf_config == NULL)

--- a/documentation.md
+++ b/documentation.md
@@ -926,7 +926,7 @@ O arquivo `config.json` é o coração da flexibilidade do PA_WIN. Abaixo está 
 **Explicação da Estrutura:**
 
 -   **Chave de Nível Superior (`"WIN$N"`):** Representa o símbolo do ativo a ser monitorado. Você pode adicionar múltiplos símbolos como chaves separadas.
--   **Chave de Timeframe (`"D1"`):** Dentro de cada símbolo, você define os timeframes que deseja monitorar. Os nomes devem corresponder às strings esperadas pelo `CConfigManager` (M1, M5, M15, M30, H1, H4, D1).
+-   **Chave de Timeframe (`"D1"`):** Dentro de cada símbolo, você define os timeframes que deseja monitorar. Os nomes são lidos diretamente do arquivo `config.json`, permitindo incluir novos timeframes sem ajustes no código-fonte.
     -   `"enabled"`: Booleano que indica se este timeframe específico para o símbolo está ativo (`true`) ou desativado (`false`).
     -   `"num_candles"`: Inteiro que especifica o número de candles a serem considerados para análise. Embora presente, seu uso direto na lógica atual pode variar e deve ser verificado no código.
     -   `"moving_averages"`: Objeto que contém as configurações para as médias móveis associadas a este timeframe.


### PR DESCRIPTION
## Summary
- iterate over timeframe keys found in config instead of using a fixed list
- document that timeframe keys are read dynamically from `config.json`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859e14dd794832094bf19bde9de134c