### PR TITLE
Implement Stochastic parameter loading

### DIFF
--- a/TF_CTX/config_manager.mqh
+++ b/TF_CTX/config_manager.mqh
@@ -31,6 +31,7 @@ private:
     string TimeframeToString(ENUM_TIMEFRAMES tf);
     ENUM_TIMEFRAMES StringToTimeframe(string tf_str);
     ENUM_MA_METHOD StringToMAMethod(string method_str);
+    ENUM_STO_PRICE StringToPriceField(string field_str);
     STimeframeConfig ParseTimeframeConfig(CJAVal *tf_config);
     string CreateContextKey(string symbol, ENUM_TIMEFRAMES tf);
     bool TestJSONParsing();
@@ -481,6 +482,16 @@ ENUM_MA_METHOD CConfigManager::StringToMAMethod(string method_str)
 }
 
 //+------------------------------------------------------------------+
+//| Converter string para price field do Estocástico                 |
+//+------------------------------------------------------------------+
+ENUM_STO_PRICE CConfigManager::StringToPriceField(string field_str)
+{
+    if(field_str == "CLOSECLOSE" || field_str == "CLOSE_CLOSE")
+        return STO_CLOSECLOSE;
+    return STO_LOWHIGH;
+}
+
+//+------------------------------------------------------------------+
 //| Fazer parse da configuração do timeframe                        |
 //+------------------------------------------------------------------+
 STimeframeConfig CConfigManager::ParseTimeframeConfig(CJAVal *tf_config)
@@ -517,6 +528,9 @@ STimeframeConfig CConfigManager::ParseTimeframeConfig(CJAVal *tf_config)
             icfg.type    = ind["type"].ToStr();
             icfg.period  = (int)ind["period"].ToInt();
             icfg.method  = StringToMAMethod(ind["method"].ToStr());
+            icfg.dperiod = (int)ind["dperiod"].ToInt();
+            icfg.slowing = (int)ind["slowing"].ToInt();
+            icfg.price_field = StringToPriceField(ind["price_field"].ToStr());
             icfg.enabled = ind["enabled"].ToBool();
 
             int pos = ArraySize(config.indicators);

--- a/TF_CTX/config_types.mqh
+++ b/TF_CTX/config_types.mqh
@@ -12,6 +12,9 @@ struct SIndicatorConfig
     string type;
     int    period;
     ENUM_MA_METHOD method;
+    int    dperiod;
+    int    slowing;
+    ENUM_STO_PRICE price_field;
     bool   enabled;
 };
 

--- a/TF_CTX/tf_ctx.mqh
+++ b/TF_CTX/tf_ctx.mqh
@@ -7,6 +7,7 @@
 #property version   "2.00"
 
 #include "indicators/moving_averages.mqh"
+#include "indicators/stochastic.mqh"
 #include "config_types.mqh"
 
 //+------------------------------------------------------------------+
@@ -84,6 +85,22 @@ bool TF_CTX::Init()
         {
          ind = new CMovingAverages();
          if(ind==NULL || !ind.Init(m_symbol, m_timeframe, m_cfg[i].period, m_cfg[i].method))
+           {
+            Print("ERRO: Falha ao inicializar indicador ", m_cfg[i].name);
+            delete ind;
+            CleanUp();
+            return false;
+           }
+        }
+      else if(m_cfg[i].type=="STO")
+        {
+         ind = new CStochastic();
+         if(ind==NULL || !((CStochastic*)ind).Init(m_symbol, m_timeframe,
+                                                  m_cfg[i].period,
+                                                  m_cfg[i].dperiod,
+                                                  m_cfg[i].slowing,
+                                                  m_cfg[i].method,
+                                                  m_cfg[i].price_field))
            {
             Print("ERRO: Falha ao inicializar indicador ", m_cfg[i].name);
             delete ind;

--- a/config.json
+++ b/config.json
@@ -7,7 +7,8 @@
             {"name":"ema9","type":"MA","period":9,"method":"EMA","enabled":true},
             {"name":"ema21","type":"MA","period":21,"method":"EMA","enabled":true},
             {"name":"ema50","type":"MA","period":50,"method":"EMA","enabled":false},
-            {"name":"sma200","type":"MA","period":200,"method":"SMA","enabled":false}
+            {"name":"sma200","type":"MA","period":200,"method":"SMA","enabled":false},
+            {"name":"sto14","type":"STO","period":14,"dperiod":3,"slowing":3,"method":"SMA","price_field":"LOWHIGH","enabled":true}
          ]
       },
       "H4": {

--- a/documentation.md
+++ b/documentation.md
@@ -90,6 +90,7 @@ Esta seção detalha cada arquivo que compõe o Expert Advisor, explicando seu p
 - **`indicator_base.mqh`**: Declara a classe abstrata `CIndicatorBase`, utilizada como interface para os diversos tipos de indicadores.
 
 - **`moving_averages.mqh`**: Implementa a classe `CMovingAverages`, derivada de `CIndicatorBase`, responsável por criar e gerenciar indicadores de média móvel.
+- **`stochastic.mqh`**: Implementa a classe `CStochastic`, derivada de `CIndicatorBase`, responsável pelo cálculo do indicador Estocástico.
 
 
 
@@ -656,8 +657,11 @@ Esta seção detalha as principais funções e classes encontradas no código do
   - **Membros**:
     - `name` (`string`): Nome do indicador.
     - `type` (`string`): Tipo do indicador (ex: `MA`).
-    - `period` (`int`): Período utilizado.
-    - `method` (`ENUM_MA_METHOD`): Método aplicado (quando aplicável).
+    - `period` (`int`): Período principal (por exemplo, %K no Estocástico).
+    - `method` (`ENUM_MA_METHOD`): Método aplicado (para médias ou suavização).
+    - `dperiod` (`int`): Período da linha %D (apenas para Estocástico).
+    - `slowing` (`int`): Valor de `slowing` (apenas para Estocástico).
+    - `price_field` (`ENUM_STO_PRICE`): Campo de preço utilizado.
     - `enabled` (`bool`): Indica se o indicador está habilitado.
 
 - **`STimeframeConfig`**
@@ -902,3 +906,7 @@ Esta seção registra as principais alterações e versões dos componentes do E
 
 
 
+
+### stochastic.mqh
+
+-   **Versao 1.00**: Implementa o indicador Estocastico derivado de `CIndicatorBase`.


### PR DESCRIPTION
## Summary
- extend `SIndicatorConfig` with stochastic params
- parse new fields from JSON via `StringToPriceField`
- initialize `CStochastic` with config data
- document new config fields
- include stochastic example in `config.json`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a02c260a083209258b6954050ee74