### PR TITLE
Add Volume indicator support

### DIFF
--- a/TF_CTX/config_manager.mqh
+++ b/TF_CTX/config_manager.mqh
@@ -530,6 +530,7 @@ STimeframeConfig CConfigManager::ParseTimeframeConfig(CJAVal *tf_config)
             icfg.method  = StringToMAMethod(ind["method"].ToStr());
             icfg.dperiod = (int)ind["dperiod"].ToInt();
             icfg.slowing = (int)ind["slowing"].ToInt();
+            icfg.shift   = (int)ind["shift"].ToInt();
             icfg.price_field = StringToPriceField(ind["price_field"].ToStr());
             icfg.enabled = ind["enabled"].ToBool();
 

--- a/TF_CTX/config_types.mqh
+++ b/TF_CTX/config_types.mqh
@@ -14,6 +14,7 @@ struct SIndicatorConfig
     ENUM_MA_METHOD method;
     int    dperiod;
     int    slowing;
+    int    shift;
     ENUM_STO_PRICE price_field;
     bool   enabled;
 };

--- a/TF_CTX/indicators/volume.mqh
+++ b/TF_CTX/indicators/volume.mqh
@@ -1,0 +1,91 @@
+//+------------------------------------------------------------------+
+//|                                    indicators/volume.mqh         |
+//|  Simple Volume indicator derived from CIndicatorBase             |
+//+------------------------------------------------------------------+
+#property copyright "Copyright 2025, MetaQuotes Ltd."
+#property link      "https://www.mql5.com"
+#property version   "1.00"
+
+#include "indicator_base.mqh"
+
+//+------------------------------------------------------------------+
+//| Classe para acesso ao volume                                     |
+//+------------------------------------------------------------------+
+class CVolume : public CIndicatorBase
+  {
+private:
+   string          m_symbol;       // Símbolo
+   ENUM_TIMEFRAMES m_timeframe;    // TimeFrame
+   int             m_base_shift;   // Shift base configurado
+
+public:
+                     CVolume();
+                    ~CVolume();
+
+   bool             Init(string symbol, ENUM_TIMEFRAMES timeframe,
+                         int base_shift, ENUM_MA_METHOD method);
+
+   virtual double   GetValue(int shift=0);
+   virtual bool     CopyValues(int shift, int count, double &buffer[]);
+   virtual bool     IsReady();
+  };
+
+//+------------------------------------------------------------------+
+//| Construtor                                                       |
+//+------------------------------------------------------------------+
+CVolume::CVolume()
+  {
+   m_symbol="";
+   m_timeframe=PERIOD_CURRENT;
+   m_base_shift=0;
+  }
+
+//+------------------------------------------------------------------+
+//| Destrutor                                                        |
+//+------------------------------------------------------------------+
+CVolume::~CVolume()
+  {
+  }
+
+//+------------------------------------------------------------------+
+//| Inicialização                                                    |
+//+------------------------------------------------------------------+
+bool CVolume::Init(string symbol, ENUM_TIMEFRAMES timeframe,
+                   int base_shift, ENUM_MA_METHOD method)
+  {
+   m_symbol      = symbol;
+   m_timeframe   = timeframe;
+   m_base_shift  = base_shift;
+   return true; // nenhuma inicialização necessária
+  }
+
+//+------------------------------------------------------------------+
+//| Obter valor de volume                                            |
+//+------------------------------------------------------------------+
+double CVolume::GetValue(int shift)
+  {
+   int index = m_base_shift + shift;
+   long vol = iVolume(m_symbol, m_timeframe, index);
+   return (double)vol;
+  }
+
+//+------------------------------------------------------------------+
+//| Copiar valores de volume                                         |
+//+------------------------------------------------------------------+
+bool CVolume::CopyValues(int shift, int count, double &buffer[])
+  {
+   ArrayResize(buffer,count);
+   ArraySetAsSeries(buffer,true);
+   for(int i=0;i<count;i++)
+      buffer[i]=(double)iVolume(m_symbol, m_timeframe, m_base_shift + shift + i);
+   return true;
+  }
+
+//+------------------------------------------------------------------+
+//| Verificar se o volume está pronto                                |
+//+------------------------------------------------------------------+
+bool CVolume::IsReady()
+  {
+   return (Bars(m_symbol,m_timeframe) > m_base_shift);
+  }
+

--- a/TF_CTX/tf_ctx.mqh
+++ b/TF_CTX/tf_ctx.mqh
@@ -8,6 +8,7 @@
 
 #include "indicators/moving_averages.mqh"
 #include "indicators/stochastic.mqh"
+#include "indicators/volume.mqh"
 #include "config_types.mqh"
 
 //+------------------------------------------------------------------+
@@ -101,6 +102,17 @@ bool TF_CTX::Init()
                                                   m_cfg[i].slowing,
                                                   m_cfg[i].method,
                                                   m_cfg[i].price_field))
+           {
+            Print("ERRO: Falha ao inicializar indicador ", m_cfg[i].name);
+            delete ind;
+            CleanUp();
+            return false;
+           }
+        }
+      else if(m_cfg[i].type=="VOL")
+        {
+         ind = new CVolume();
+         if(ind==NULL || !ind.Init(m_symbol, m_timeframe, m_cfg[i].shift, m_cfg[i].method))
            {
             Print("ERRO: Falha ao inicializar indicador ", m_cfg[i].name);
             delete ind;

--- a/config.json
+++ b/config.json
@@ -8,7 +8,8 @@
             {"name":"ema21","type":"MA","period":21,"method":"EMA","enabled":true},
             {"name":"ema50","type":"MA","period":50,"method":"EMA","enabled":false},
             {"name":"sma200","type":"MA","period":200,"method":"SMA","enabled":false},
-            {"name":"sto14","type":"STO","period":14,"dperiod":3,"slowing":3,"method":"SMA","price_field":"LOWHIGH","enabled":true}
+            {"name":"sto14","type":"STO","period":14,"dperiod":3,"slowing":3,"method":"SMA","price_field":"LOWHIGH","enabled":true},
+            {"name":"vol0","type":"VOL","shift":0,"enabled":true}
          ]
       },
       "H4": {
@@ -18,7 +19,8 @@
             {"name":"ema9","type":"MA","period":9,"method":"SMA","enabled":true},
             {"name":"ema21","type":"MA","period":21,"method":"EMA","enabled":false},
             {"name":"ema50","type":"MA","period":50,"method":"EMA","enabled":false},
-            {"name":"sma200","type":"MA","period":200,"method":"SMA","enabled":true}
+            {"name":"sma200","type":"MA","period":200,"method":"SMA","enabled":true},
+            {"name":"vol0","type":"VOL","shift":0,"enabled":false}
          ]
       }
    }

--- a/documentation.md
+++ b/documentation.md
@@ -91,6 +91,7 @@ Esta seção detalha cada arquivo que compõe o Expert Advisor, explicando seu p
 
 - **`moving_averages.mqh`**: Implementa a classe `CMovingAverages`, derivada de `CIndicatorBase`, responsável por criar e gerenciar indicadores de média móvel.
 - **`stochastic.mqh`**: Implementa a classe `CStochastic`, derivada de `CIndicatorBase`, responsável pelo cálculo do indicador Estocástico.
+- **`volume.mqh`**: Implementa a classe `CVolume`, derivada de `CIndicatorBase`, responsável por acessar valores de volume.
 
 
 
@@ -661,6 +662,7 @@ Esta seção detalha as principais funções e classes encontradas no código do
     - `method` (`ENUM_MA_METHOD`): Método aplicado (para médias ou suavização).
     - `dperiod` (`int`): Período da linha %D (apenas para Estocástico).
     - `slowing` (`int`): Valor de `slowing` (apenas para Estocástico).
+    - `shift` (`int`): Deslocamento base para indicadores que utilizam série de preços (ex: Volume).
     - `price_field` (`ENUM_STO_PRICE`): Campo de preço utilizado.
     - `enabled` (`bool`): Indica se o indicador está habilitado.
 
@@ -910,3 +912,7 @@ Esta seção registra as principais alterações e versões dos componentes do E
 ### stochastic.mqh
 
 -   **Versao 1.00**: Implementa o indicador Estocastico derivado de `CIndicatorBase`.
+
+### volume.mqh
+
+-   **Versao 1.00**: Implementa o indicador de Volume derivado de `CIndicatorBase`.


### PR DESCRIPTION
## Summary
- implement new `CVolume` indicator derived from `CIndicatorBase`
- support `VOL` indicator type in `TF_CTX`
- extend config structures and parser with `shift` field
- add example volume indicators in `config.json`
- update docs to reference volume indicator and new config field

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a275d12948320a90317a3e2a0d2f3