### PR TITLE
Add VWAP indicator

### DIFF
--- a/TF_CTX/indicators/vwap.mqh
+++ b/TF_CTX/indicators/vwap.mqh
@@ -1,0 +1,108 @@
+//+------------------------------------------------------------------+
+//|                                    indicators/vwap.mqh           |
+//|  Volume Weighted Average Price indicator                         |
+//+------------------------------------------------------------------+
+#ifndef __VWAP_MQH__
+#define __VWAP_MQH__
+
+#include "indicator_base.mqh"
+
+class CVWAP : public CIndicatorBase
+  {
+private:
+   string          m_symbol;
+   ENUM_TIMEFRAMES m_timeframe;
+   int             m_period;
+
+   double          CalcVWAP(int shift);
+public:
+                     CVWAP();
+                    ~CVWAP();
+
+   virtual bool     Init(string symbol, ENUM_TIMEFRAMES timeframe,
+                         int period, ENUM_MA_METHOD method);
+   virtual double   GetValue(int shift=0);
+   virtual bool     CopyValues(int shift,int count,double &buffer[]);
+   virtual bool     IsReady();
+  };
+
+//+------------------------------------------------------------------+
+//| Constructor                                                      |
+//+------------------------------------------------------------------+
+CVWAP::CVWAP()
+  {
+   m_symbol="";
+   m_timeframe=PERIOD_CURRENT;
+   m_period=1;
+  }
+
+//+------------------------------------------------------------------+
+//| Destructor                                                       |
+//+------------------------------------------------------------------+
+CVWAP::~CVWAP()
+  {
+  }
+
+//+------------------------------------------------------------------+
+//| Initialization                                                   |
+//+------------------------------------------------------------------+
+bool CVWAP::Init(string symbol, ENUM_TIMEFRAMES timeframe,
+                 int period, ENUM_MA_METHOD method)
+  {
+   m_symbol=symbol;
+   m_timeframe=timeframe;
+   if(period>0) m_period=period; else m_period=1;
+   return true;
+  }
+
+//+------------------------------------------------------------------+
+//| Calculate VWAP for given shift                                   |
+//+------------------------------------------------------------------+
+double CVWAP::CalcVWAP(int shift)
+  {
+   double sum_pv=0.0;
+   double sum_vol=0.0;
+   for(int i=shift;i<shift+m_period;i++)
+     {
+      double high=iHigh(m_symbol,m_timeframe,i);
+      double low=iLow(m_symbol,m_timeframe,i);
+      double close=iClose(m_symbol,m_timeframe,i);
+      long   vol=iVolume(m_symbol,m_timeframe,i);
+      double typical=(high+low+close)/3.0;
+      sum_pv += typical*vol;
+      sum_vol += vol;
+     }
+   if(sum_vol==0.0)
+      return 0.0;
+   return sum_pv/sum_vol;
+  }
+
+//+------------------------------------------------------------------+
+//| Get single value                                                 |
+//+------------------------------------------------------------------+
+double CVWAP::GetValue(int shift)
+  {
+   return CalcVWAP(shift);
+  }
+
+//+------------------------------------------------------------------+
+//| Copy multiple values                                             |
+//+------------------------------------------------------------------+
+bool CVWAP::CopyValues(int shift,int count,double &buffer[])
+  {
+   ArrayResize(buffer,count);
+   ArraySetAsSeries(buffer,true);
+   for(int j=0;j<count;j++)
+      buffer[j]=CalcVWAP(shift+j);
+   return true;
+  }
+
+//+------------------------------------------------------------------+
+//| Check readiness                                                  |
+//+------------------------------------------------------------------+
+bool CVWAP::IsReady()
+  {
+   return (Bars(m_symbol,m_timeframe) > m_period);
+  }
+
+#endif // __VWAP_MQH__

--- a/TF_CTX/tf_ctx.mqh
+++ b/TF_CTX/tf_ctx.mqh
@@ -9,6 +9,7 @@
 #include "indicators/moving_averages.mqh"
 #include "indicators/stochastic.mqh"
 #include "indicators/volume.mqh"
+#include "indicators/vwap.mqh"
 #include "indicators/bollinger.mqh"
 #include "indicators/fibonacci.mqh"
 #include "config_types.mqh"
@@ -18,6 +19,7 @@ enum ENUM_INDICATOR_TYPE
   INDICATOR_TYPE_MA,
   INDICATOR_TYPE_STO,
   INDICATOR_TYPE_VOL,
+  INDICATOR_TYPE_VWAP,
   INDICATOR_TYPE_BOLL,
   INDICATOR_TYPE_FIBO,
   INDICATOR_TYPE_UNKNOWN
@@ -31,6 +33,8 @@ ENUM_INDICATOR_TYPE StringToIndicatorType(string type)
     return INDICATOR_TYPE_STO;
   if (type == "VOL")
     return INDICATOR_TYPE_VOL;
+  if (type == "VWAP")
+    return INDICATOR_TYPE_VWAP;
   if (type == "BOLL")
     return INDICATOR_TYPE_BOLL;
   if (type == "FIBO")
@@ -135,6 +139,17 @@ bool TF_CTX::Init()
     case INDICATOR_TYPE_VOL:
       ind = new CVolume();
       if (ind == NULL || !ind.Init(m_symbol, m_timeframe, m_cfg[i].shift, m_cfg[i].method))
+      {
+        Print("ERRO: Falha ao inicializar indicador ", m_cfg[i].name);
+        delete ind;
+        CleanUp();
+        return false;
+      }
+      break;
+
+    case INDICATOR_TYPE_VWAP:
+      ind = new CVWAP();
+      if (ind == NULL || !ind.Init(m_symbol, m_timeframe, m_cfg[i].period, m_cfg[i].method))
       {
         Print("ERRO: Falha ao inicializar indicador ", m_cfg[i].name);
         delete ind;

--- a/config.json
+++ b/config.json
@@ -10,6 +10,7 @@
             {"name":"sma200","type":"MA","period":200,"method":"SMA","enabled":false},
             {"name":"sto14","type":"STO","period":14,"dperiod":3,"slowing":3,"method":"SMA","price_field":"LOWHIGH","enabled":true},
             {"name":"vol0","type":"VOL","shift":0,"enabled":true},
+            {"name":"vwap14","type":"VWAP","period":14,"enabled":true},
             {"name":"boll20","type":"BOLL","period":20,"shift":0,"deviation":2.0,"applied_price":"CLOSE","enabled":true},
             {"name":"fibo_complete","type":"FIBO","period":30,
              "Level_1":23.6,"Level_2":38.2,"Level_3":50.0,

--- a/documentation.md
+++ b/documentation.md
@@ -92,6 +92,7 @@ Esta seção detalha cada arquivo que compõe o Expert Advisor, explicando seu p
 - **`moving_averages.mqh`**: Implementa a classe `CMovingAverages`, derivada de `CIndicatorBase`, responsável por criar e gerenciar indicadores de média móvel.
 - **`stochastic.mqh`**: Implementa a classe `CStochastic`, derivada de `CIndicatorBase`, responsável pelo cálculo do indicador Estocástico.
 - **`volume.mqh`**: Implementa a classe `CVolume`, derivada de `CIndicatorBase`, responsável por acessar valores de volume.
+- **`vwap.mqh`**: Implementa a classe `CVWAP`, derivada de `CIndicatorBase`, responsável pelo cálculo do Volume Weighted Average Price.
 - **`fibonacci.mqh`**: Implementa o indicador `CFibonacci`, capaz de desenhar níveis de retração e extensões de Fibonacci com total customização via JSON.
 
 
@@ -936,6 +937,10 @@ Esta seção registra as principais alterações e versões dos componentes do E
 ### volume.mqh
 
 -   **Versao 1.00**: Implementa o indicador de Volume derivado de `CIndicatorBase`.
+
+### vwap.mqh
+
+-   **Versao 1.00**: Implementa o indicador VWAP (Volume Weighted Average Price) derivado de `CIndicatorBase`.
 
 ### fibonacci.mqh
 


### PR DESCRIPTION
## Summary
- implement `CVWAP` indicator for Volume Weighted Average Price
- hook VWAP into `TF_CTX`
- document new indicator and update configuration example
- add VWAP instance in `config.json`

## Testing
- `grep -R "TODO" -n | head`

------
https://chatgpt.com/codex/tasks/task_e_685c4cf735c883209571bbee23f6fb5e