### PR TITLE
Enable VWAP color in JSON

### DIFF
--- a/TF_CTX/config_manager.mqh
+++ b/TF_CTX/config_manager.mqh
@@ -594,11 +594,12 @@ STimeframeConfig CConfigManager::ParseTimeframeConfig(CJAVal *tf_config)
     {
         for(int i=0;i<ind_array.Size();i++)
         {
-            CJAVal *ind = (*ind_array)[i];
-            if(ind==NULL) continue;
+           CJAVal *ind = (*ind_array)[i];
+           if(ind==NULL) continue;
 
-            SIndicatorConfig icfg; icfg.InitDefaults();
-            icfg.name    = ind["name"].ToStr();
+           SIndicatorConfig icfg; icfg.InitDefaults();
+           string col="";
+           icfg.name    = ind["name"].ToStr();
             icfg.type    = ind["type"].ToStr();
             icfg.period  = (int)ind["period"].ToInt();
             icfg.method  = StringToMAMethod(ind["method"].ToStr());
@@ -611,16 +612,18 @@ STimeframeConfig CConfigManager::ParseTimeframeConfig(CJAVal *tf_config)
             icfg.vwap_calc_mode = StringToVWAPCalcMode(ind["calc_mode"].ToStr());
             icfg.vwap_session_tf = StringToTimeframe(ind["session_tf"].ToStr());
             icfg.vwap_price_type = StringToVWAPPriceType(ind["price_type"].ToStr());
-            string start_str = ind["start_time"].ToStr();
-            if(StringLen(start_str)>0) icfg.vwap_start_time = StringToTime(start_str);
-            icfg.enabled = ind["enabled"].ToBool();
+           string start_str = ind["start_time"].ToStr();
+           if(StringLen(start_str)>0) icfg.vwap_start_time = StringToTime(start_str);
+           col=ind["Color"].ToStr();
+           icfg.vwap_color = StringToColor(col);
+           icfg.enabled = ind["enabled"].ToBool();
             icfg.level_1 = ind["Level_1"].ToDbl();
             icfg.level_2 = ind["Level_2"].ToDbl();
             icfg.level_3 = ind["Level_3"].ToDbl();
             icfg.level_4 = ind["Level_4"].ToDbl();
             icfg.level_5 = ind["Level_5"].ToDbl();
             icfg.level_6 = ind["Level_6"].ToDbl();
-            string col=ind["LevelsColor"].ToStr();
+           col=ind["LevelsColor"].ToStr();
             icfg.levels_color = StringToColor(col);
             icfg.levels_style = StringToLineStyle(ind["LevelsStyle"].ToStr());
             icfg.levels_width = (int)ind["LevelsWidth"].ToInt();

--- a/TF_CTX/config_types.mqh
+++ b/TF_CTX/config_types.mqh
@@ -24,6 +24,7 @@ struct SIndicatorConfig
     ENUM_TIMEFRAMES     vwap_session_tf;
     ENUM_VWAP_PRICE_TYPE vwap_price_type;
     datetime            vwap_start_time;
+    color  vwap_color;
     bool   enabled;
     double level_1;
     double level_2;
@@ -65,6 +66,7 @@ struct SIndicatorConfig
        vwap_session_tf=PERIOD_D1;
        vwap_price_type=VWAP_PRICE_FINANCIAL_AVERAGE;
        vwap_start_time=0;
+       vwap_color=clrAqua;
        enabled=true;
        level_1=23.6; level_2=38.2; level_3=50.0;
        level_4=61.8; level_5=78.6; level_6=100.0;

--- a/TF_CTX/indicators/vwap.mqh
+++ b/TF_CTX/indicators/vwap.mqh
@@ -64,7 +64,8 @@ public:
                         ENUM_VWAP_CALC_MODE calc_mode,
                         ENUM_TIMEFRAMES session_tf,
                         ENUM_VWAP_PRICE_TYPE price_type,
-                        datetime start_time);
+                        datetime start_time,
+                        color line_color);
   virtual bool     Init(string symbol, ENUM_TIMEFRAMES timeframe,
                         int period, ENUM_MA_METHOD method);
    virtual double   GetValue(int shift=0);
@@ -116,7 +117,8 @@ bool CVWAP::Init(string symbol, ENUM_TIMEFRAMES timeframe,
                  ENUM_VWAP_CALC_MODE calc_mode,
                  ENUM_TIMEFRAMES session_tf,
                  ENUM_VWAP_PRICE_TYPE price_type,
-                 datetime start_time)
+                 datetime start_time,
+                 color line_color)
   {
    m_symbol=symbol;
    m_timeframe=timeframe;
@@ -125,6 +127,7 @@ bool CVWAP::Init(string symbol, ENUM_TIMEFRAMES timeframe,
    m_price_type=price_type;
    m_session_tf=session_tf;
    m_start_time=start_time;
+   m_color=line_color;
    m_last_calculated_time=0;
    ArrayResize(m_vwap_buffer,0);
    return true;
@@ -138,7 +141,7 @@ bool CVWAP::Init(string symbol, ENUM_TIMEFRAMES timeframe,
   {
    return Init(symbol,timeframe,period,method,
                VWAP_CALC_BAR,PERIOD_D1,
-               VWAP_PRICE_FINANCIAL_AVERAGE,0);
+               VWAP_PRICE_FINANCIAL_AVERAGE,0,clrAqua);
   }
 
 //+------------------------------------------------------------------+

--- a/TF_CTX/tf_ctx.mqh
+++ b/TF_CTX/tf_ctx.mqh
@@ -152,7 +152,7 @@ bool TF_CTX::Init()
       if (ind == NULL || !((CVWAP*)ind).Init(m_symbol, m_timeframe, m_cfg[i].period,
                                            m_cfg[i].method, m_cfg[i].vwap_calc_mode,
                                            m_cfg[i].vwap_session_tf, m_cfg[i].vwap_price_type,
-                                           m_cfg[i].vwap_start_time))
+                                           m_cfg[i].vwap_start_time, m_cfg[i].vwap_color))
       {
         Print("ERRO: Falha ao inicializar indicador ", m_cfg[i].name);
         delete ind;

--- a/config.json
+++ b/config.json
@@ -55,6 +55,7 @@
                "calc_mode": "PERIODIC",
                "session_tf": "D1",
                "price_type": "FINANCIAL_AVERAGE",
+               "Color": "Blue",
                "enabled": true
             },
             {

--- a/documentation.md
+++ b/documentation.md
@@ -666,6 +666,7 @@ Esta seção detalha as principais funções e classes encontradas no código do
     - `slowing` (`int`): Valor de `slowing` (apenas para Estocástico).
     - `shift` (`int`): Deslocamento base para indicadores que utilizam série de preços (ex: Volume).
     - `price_field` (`ENUM_STO_PRICE`): Campo de preço utilizado.
+    - `vwap_calc_mode`, `vwap_session_tf`, `vwap_price_type`, `vwap_start_time`, `vwap_color`: Parâmetros específicos do indicador VWAP.
     - `enabled` (`bool`): Indica se o indicador está habilitado.
     - `level_1` a `level_6` (`double`): Valores dos níveis de retração de Fibonacci.
     - `levels_color`, `levels_style`, `levels_width`: Aparência das linhas de retração.
@@ -849,7 +850,7 @@ O arquivo `config.json` é o coração da flexibilidade do PA_WIN. Abaixo está 
 
 ### Paleta de Cores Disponível
 
-Os campos `LevelsColor`, `ExtensionsColor`, `ParallelColor` e `LabelsColor` utilizam nomes de cores em formato de string. As cores reconhecidas atualmente são:
+Os campos `LevelsColor`, `ExtensionsColor`, `ParallelColor`, `LabelsColor` e `Color` utilizam nomes de cores em formato de string. As cores reconhecidas atualmente são:
 
 - `Red`
 - `Blue`
@@ -906,6 +907,7 @@ Os campos `LevelsColor`, `ExtensionsColor`, `ParallelColor` e `LabelsColor` util
        "session_tf": "D1",
        "price_type": "HLC3",
        "start_time": "2025-01-01 09:00:00",
+       "Color": "Blue",
        "enabled": true
     }
     ```
@@ -913,6 +915,7 @@ Os campos `LevelsColor`, `ExtensionsColor`, `ParallelColor` e `LabelsColor` util
     - `session_tf`: timeframe utilizado para detectar o início das sessões (por exemplo, `D1` ou `W1`).
     - `price_type`: forma de cálculo do preço típico, como `OPEN`, `CLOSE`, `HL2`, `HLC3` ou `OHLC4`.
     - `start_time`: usado apenas no modo `FROM_DATE` para indicar a data/hora inicial.
+    - `Color`: define a cor da linha de VWAP.
 
     Exemplo de configuração para cálculo **PERIODIC**, sessão diária, com preço
     de **média financeira**:
@@ -925,6 +928,7 @@ Os campos `LevelsColor`, `ExtensionsColor`, `ParallelColor` e `LabelsColor` util
        "calc_mode": "PERIODIC",
        "session_tf": "D1",
        "price_type": "FINANCIAL_AVERAGE",
+       "Color": "Blue",
        "enabled": true
     }
     ```
@@ -980,6 +984,7 @@ Esta seção registra as principais alterações e versões dos componentes do E
 -   **Versao 3.00**: Reescrita completa com cálculo acumulado por sessão, modos de cálculo e suporte a diferentes tipos de preço.
 -   **Versao 4.00**: Corrige o cálculo por barras, inclui métodos de configuração e atualização incremental.
 -   **Versao 5.00**: Melhora a detecção de sessões e o cálculo da barra atual.
+-   **Versao 6.00**: Permite definir a cor da linha VWAP via JSON.
 
 ### fibonacci.mqh
 


### PR DESCRIPTION
## Summary
- allow VWAP color configuration through JSON
- document VWAP `Color` field in examples
- show new VWAP version in changelog

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d7fa34e8883209092a41ac0d119dc