### PR TITLE
Implement advanced trend line scoring

### DIFF
--- a/TF_CTX/config_manager.mqh
+++ b/TF_CTX/config_manager.mqh
@@ -38,6 +38,7 @@ private:
     ENUM_LINE_STYLE StringToLineStyle(string style_str);
     color StringToColor(string color_str);
     STimeframeConfig ParseTimeframeConfig(CJAVal *tf_config);
+    ScoreWeights ParseScoreWeights(CJAVal *sc_config);
     string CreateContextKey(string symbol, ENUM_TIMEFRAMES tf);
     bool TestJSONParsing();
     
@@ -558,9 +559,36 @@ color CConfigManager::StringToColor(string color_str)
     if(color_str=="Lime")   return clrLime;
     if(color_str=="Magenta") return clrMagenta;
     if(color_str=="Cyan")   return clrCyan;
-    if(StringLen(color_str)>0)
-       return (color)StringToInteger(color_str);
-    return clrNONE;
+   if(StringLen(color_str)>0)
+      return (color)StringToInteger(color_str);
+   return clrNONE;
+}
+
+//+------------------------------------------------------------------+
+//| Parsear pesos de scoring                                         |
+//+------------------------------------------------------------------+
+ScoreWeights CConfigManager::ParseScoreWeights(CJAVal *sc_config)
+{
+    ScoreWeights w;
+    if(sc_config==NULL)
+        return w;
+
+    if((*sc_config)["trend_weight"]!=NULL)
+        w.trend_weight = (*sc_config)["trend_weight"].ToDbl();
+    if((*sc_config)["volume_weight"]!=NULL)
+        w.volume_weight = (*sc_config)["volume_weight"].ToDbl();
+    if((*sc_config)["tests_weight"]!=NULL)
+        w.tests_weight = (*sc_config)["tests_weight"].ToDbl();
+    if((*sc_config)["time_weight"]!=NULL)
+        w.time_weight = (*sc_config)["time_weight"].ToDbl();
+    if((*sc_config)["psychological_weight"]!=NULL)
+        w.psychological_weight = (*sc_config)["psychological_weight"].ToDbl();
+    if((*sc_config)["volatility_weight"]!=NULL)
+        w.volatility_weight = (*sc_config)["volatility_weight"].ToDbl();
+    if((*sc_config)["mtf_weight"]!=NULL)
+        w.mtf_weight = (*sc_config)["mtf_weight"].ToDbl();
+
+    return w;
 }
 
 //+------------------------------------------------------------------+
@@ -748,10 +776,12 @@ STimeframeConfig CConfigManager::ParseTimeframeConfig(CJAVal *tf_config)
               p.show_labels=pa["show_labels"].ToBool();
               p.stability_bars=(int)pa["stability_bars"].ToInt();
               p.min_distance=(int)pa["min_distance"].ToInt();
-              p.validate_mtf=pa["validate_mtf"].ToBool();
-              string mtf=pa["mtf_timeframe"].ToStr();
-              if(StringLen(mtf)>0) p.mtf_timeframe=StringToTimeframe(mtf);
-              
+             p.validate_mtf=pa["validate_mtf"].ToBool();
+             string mtf=pa["mtf_timeframe"].ToStr();
+             if(StringLen(mtf)>0) p.mtf_timeframe=StringToTimeframe(mtf);
+             CJAVal *sc=pa["scoring"];
+             p.weights=ParseScoreWeights(sc);
+
               pacfg=p;
              }
 

--- a/TF_CTX/config_types.mqh
+++ b/TF_CTX/config_types.mqh
@@ -196,6 +196,7 @@ public:
   int  min_distance;             // distância mínima entre fractais
   bool validate_mtf;             // validar com timeframe superior
   ENUM_TIMEFRAMES mtf_timeframe; // timeframe para validação
+  ScoreWeights    weights;       // pesos para o algoritmo de scoring
   
   CTrendLineConfig()
   {
@@ -217,6 +218,7 @@ public:
     min_distance = 5;
     validate_mtf = false;
     mtf_timeframe = PERIOD_H1;
+    weights = ScoreWeights();
   }
 };
 

--- a/TF_CTX/priceaction/trendline/trendline.mqh
+++ b/TF_CTX/priceaction/trendline/trendline.mqh
@@ -823,7 +823,7 @@ double CTrendLine::ComputeVolatilityContext(SFractalPoint &p1, SFractalPoint &p2
    int dist=p1.bar_index-p2.bar_index;
    if(dist<=0) return 0.0;
    double slope=MathAbs((p2.price-p1.price)/dist);
-   double atr=iATR(m_symbol,m_timeframe,14,0);
+   double atr=iATR(m_symbol,m_timeframe,14);
    if(atr<=0) return 50.0;
    double rel=slope/atr;
    return MathMin(rel*50.0,100.0);

--- a/TF_CTX/priceaction/trendline/trendline.mqh
+++ b/TF_CTX/priceaction/trendline/trendline.mqh
@@ -101,6 +101,7 @@ private:
   LineVersion     m_lta_version;
   LineVersion     m_ltb_version;
   bool            m_need_redraw;
+  ScoreWeights    m_weights;
    
    // Métodos privados
    bool            CreateFractalsHandle();
@@ -114,6 +115,12 @@ private:
    bool            IsValidLTA(SFractalPoint &p1, SFractalPoint &p2);
    bool            IsValidLTB(SFractalPoint &p1, SFractalPoint &p2);
    double          ScorePair(SFractalPoint &p1, SFractalPoint &p2);
+   double          ComputeTrendStrength(SFractalPoint &p1, SFractalPoint &p2);
+   double          ComputeVolumeConfirmation(SFractalPoint &p1, SFractalPoint &p2);
+   double          ComputeLineTests(SFractalPoint &p1, SFractalPoint &p2);
+   double          ComputeTimeValidity(SFractalPoint &p1, SFractalPoint &p2);
+   double          ComputePsychologicalLevel(SFractalPoint &p1, SFractalPoint &p2);
+   double          ComputeVolatilityContext(SFractalPoint &p1, SFractalPoint &p2);
    void            UpdateTrendState(TrendLineState &state, SFractalPoint &p1, SFractalPoint &p2);
    bool            ValidateLineWithMTF(SFractalPoint &p1, SFractalPoint &p2);
 
@@ -175,6 +182,7 @@ CTrendLine::CTrendLine()
    m_validate_mtf = false;
    m_mtf_timeframe = PERIOD_H1;
    m_need_redraw = true;
+   m_weights = ScoreWeights();
 
    m_low_cache.confirmation_bars = m_confirm_bars;
    m_high_cache.confirmation_bars = m_confirm_bars;
@@ -225,6 +233,7 @@ bool CTrendLine::Init(string symbol, ENUM_TIMEFRAMES timeframe, CTrendLineConfig
   m_min_distance = config.min_distance;
   m_validate_mtf = config.validate_mtf;
   m_mtf_timeframe = config.mtf_timeframe;
+  m_weights = config.weights;
    
    // Criar nomes únicos para objetos
    string suffix = "_" + m_symbol + "_" + EnumToString(m_timeframe) + "_" + IntegerToString(GetTickCount());
@@ -728,8 +737,96 @@ double CTrendLine::ScorePair(SFractalPoint &p1, SFractalPoint &p2)
    int dist = p1.bar_index - p2.bar_index;
    if(dist <= 0)
       return -1.0;
-   double slope = MathAbs((p2.price - p1.price) / (double)dist);
-   return slope * dist;
+
+   TrendLineQuality q;
+   q.trend_strength      = ComputeTrendStrength(p1,p2);
+   q.volume_confirmation = ComputeVolumeConfirmation(p1,p2);
+   q.line_tests          = ComputeLineTests(p1,p2);
+   q.time_validity       = ComputeTimeValidity(p1,p2);
+   q.psychological_level = ComputePsychologicalLevel(p1,p2);
+   q.volatility_context  = ComputeVolatilityContext(p1,p2);
+   q.mtf_alignment       = ValidateLineWithMTF(p1,p2) ? 100.0 : 0.0;
+
+   double total_w = m_weights.trend_weight + m_weights.volume_weight +
+                    m_weights.tests_weight + m_weights.time_weight +
+                    m_weights.psychological_weight + m_weights.volatility_weight +
+                    m_weights.mtf_weight;
+   if(total_w<=0.0) total_w=1.0;
+
+   double score =
+       q.trend_strength      * m_weights.trend_weight +
+       q.volume_confirmation * m_weights.volume_weight +
+       q.line_tests          * m_weights.tests_weight +
+       q.time_validity       * m_weights.time_weight +
+       q.psychological_level * m_weights.psychological_weight +
+       q.volatility_context  * m_weights.volatility_weight +
+       q.mtf_alignment       * m_weights.mtf_weight;
+
+   return score / total_w;
+}
+
+//--- Cálculo dos fatores individuais ---
+double CTrendLine::ComputeTrendStrength(SFractalPoint &p1, SFractalPoint &p2)
+{
+   int dist=p1.bar_index-p2.bar_index;
+   if(dist<=0) return 0.0;
+   double slope=MathAbs((p2.price-p1.price)/dist);
+   double rel=slope/MathMax(p1.price,1);
+   return MathMin(rel*10000.0,100.0);
+}
+
+double CTrendLine::ComputeVolumeConfirmation(SFractalPoint &p1, SFractalPoint &p2)
+{
+   double v1=iVolume(m_symbol,m_timeframe,p1.bar_index);
+   double v2=iVolume(m_symbol,m_timeframe,p2.bar_index);
+   double sum=0; int count=0;
+   for(int i=0;i<20 && i<Bars(m_symbol,m_timeframe);i++)
+   { sum+=iVolume(m_symbol,m_timeframe,i); count++; }
+   double avg=(count>0)?sum/count:1.0;
+   double rel=((v1+v2)/2.0)/MathMax(avg,1.0);
+   return MathMin(rel*100.0,100.0);
+}
+
+double CTrendLine::ComputeLineTests(SFractalPoint &p1, SFractalPoint &p2)
+{
+   int tests=0;
+   for(int i=p1.bar_index-1;i>p2.bar_index;i--)
+   {
+      double price=CalculateLinePrice(p1,p2,i);
+      double hi=iHigh(m_symbol,m_timeframe,i);
+      double lo=iLow(m_symbol,m_timeframe,i);
+      if(price>=lo && price<=hi)
+         tests++;
+   }
+   return MathMin(tests*50.0,100.0); // 2 ou mais toques = 100
+}
+
+double CTrendLine::ComputeTimeValidity(SFractalPoint &p1, SFractalPoint &p2)
+{
+   int dist=p1.bar_index-p2.bar_index;
+   return MathMin(dist*10.0,100.0);
+}
+
+double CTrendLine::ComputePsychologicalLevel(SFractalPoint &p1, SFractalPoint &p2)
+{
+   double step=100.0;
+   double diff1=MathAbs(p1.price-MathRound(p1.price/step)*step);
+   double diff2=MathAbs(p2.price-MathRound(p2.price/step)*step);
+   double diff=(diff1+diff2)/2.0;
+   double score=100.0-(diff/(step*0.5))*100.0;
+   if(score<0) score=0.0;
+   return MathMin(score,100.0);
+}
+
+double CTrendLine::ComputeVolatilityContext(SFractalPoint &p1, SFractalPoint &p2)
+{
+   int dist=p1.bar_index-p2.bar_index;
+   if(dist<=0) return 0.0;
+   double slope=MathAbs((p2.price-p1.price)/dist);
+   double atr=iATR(m_symbol,m_timeframe,14,0);
+   if(atr<=0) return 50.0;
+   double rel=slope/atr;
+   return MathMin(rel*50.0,100.0);
 }
 
 //+------------------------------------------------------------------+

--- a/TF_CTX/priceaction/trendline/trendline_defs.mqh
+++ b/TF_CTX/priceaction/trendline/trendline_defs.mqh
@@ -24,4 +24,50 @@ enum ENUM_TRENDLINE_DIRECTION
    TRENDLINE_HORIZONTAL = 2  // Linha horizontal
   };
 
+// Estrutura representando a qualidade de uma linha de tendência
+struct TrendLineQuality
+  {
+   double trend_strength;      // Consistência da direção
+   double volume_confirmation; // Volume nos pontos fractais
+   double line_tests;          // Quantas vezes preço tocou a linha
+   double time_validity;       // Quanto tempo a linha se mantém válida
+   double psychological_level; // Proximidade de números redondos
+   double volatility_context;  // Relação com volatilidade média
+   double mtf_alignment;       // Alinhamento com timeframes maiores
+
+   TrendLineQuality()
+     {
+      trend_strength=0.0;
+      volume_confirmation=0.0;
+      line_tests=0.0;
+      time_validity=0.0;
+      psychological_level=0.0;
+      volatility_context=0.0;
+      mtf_alignment=0.0;
+     }
+  };
+
+// Pesos configuráveis para o score final
+struct ScoreWeights
+  {
+   double trend_weight;
+   double volume_weight;
+   double tests_weight;
+   double time_weight;
+   double psychological_weight;
+   double volatility_weight;
+   double mtf_weight;
+
+   ScoreWeights()
+     {
+      trend_weight=0.25;
+      volume_weight=0.15;
+      tests_weight=0.20;
+      time_weight=0.10;
+      psychological_weight=0.10;
+      volatility_weight=0.10;
+      mtf_weight=0.10;
+     }
+  };
+
 #endif // __TRENDLINE_DEFS_MQH__

--- a/config.json
+++ b/config.json
@@ -149,6 +149,15 @@
                "min_distance": 5,
                "validate_mtf": false,
                "mtf_timeframe": "D1",
+               "scoring": {
+                   "trend_weight": 0.25,
+                   "volume_weight": 0.15,
+                   "tests_weight": 0.20,
+                   "time_weight": 0.10,
+                   "psychological_weight": 0.10,
+                   "volatility_weight": 0.10,
+                   "mtf_weight": 0.10
+               },
                "enabled": true
             }
          ],


### PR DESCRIPTION
## Summary
- add TrendLineQuality and ScoreWeights definitions
- parse scoring weights from JSON config
- store weights in `CTrendLine` and compute composite score using several quality factors
- calculate trend strength, volume confirmation, line tests, time validity, psychological proximity and volatility context
- include scoring weights in sample config

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_685ee24880848320b8333fb750258e24