### PR TITLE
Atualizações no módulo TrendLine

### DIFF
--- a/TF_CTX/config_manager.mqh
+++ b/TF_CTX/config_manager.mqh
@@ -794,9 +794,13 @@ STimeframeConfig CConfigManager::ParseTimeframeConfig(CJAVal *tf_config)
               p.ltb_style=StringToLineStyle(pa["ltb_style"].ToStr());
               p.lta_width=(int)pa["lta_width"].ToInt();
               p.ltb_width=(int)pa["ltb_width"].ToInt();
-              p.extend_right=pa["extend_right"].ToBool();
-              p.show_labels=pa["show_labels"].ToBool();
-              p.stability_bars=(int)pa["stability_bars"].ToInt();
+             p.extend_right=pa["extend_right"].ToBool();
+             p.show_labels=pa["show_labels"].ToBool();
+             p.extend_bars=(int)pa["extend_bars"].ToInt();
+             if(p.extend_bars<=0) p.extend_bars=20;
+             p.label_offset=pa["label_offset"].ToDbl();
+             if(p.label_offset<=0) p.label_offset=50.0;
+             p.stability_bars=(int)pa["stability_bars"].ToInt();
               p.min_distance=(int)pa["min_distance"].ToInt();
              p.validate_mtf=pa["validate_mtf"].ToBool();
              string mtf=pa["mtf_timeframe"].ToStr();

--- a/TF_CTX/config_types.mqh
+++ b/TF_CTX/config_types.mqh
@@ -192,6 +192,8 @@ public:
   int ltb_width;                 // largura da LTB
   bool extend_right;             // estender linhas para a direita
   bool show_labels;              // mostrar rótulos nas linhas
+  int  extend_bars;              // quantas barras projetar para a direita
+  double label_offset;           // deslocamento vertical dos rótulos (pontos)
   int  stability_bars;           // mínimo de barras para confirmar
   int  min_distance;             // distância mínima entre fractais
   bool validate_mtf;             // validar com timeframe superior
@@ -215,6 +217,8 @@ public:
     ltb_width = 1;
     extend_right = true;
     show_labels = false;
+    extend_bars = 20;
+    label_offset = 50.0;
     stability_bars = 2;
     min_distance = 5;
     validate_mtf = false;

--- a/config.json
+++ b/config.json
@@ -144,6 +144,8 @@
                "lta_width": 1,
                "ltb_width": 1,
                "extend_right": true,
+               "extend_bars": 20,
+               "label_offset": 50,
                "show_labels": true,
                "stability_bars": 2,
                "min_distance": 5,

--- a/documentation.md
+++ b/documentation.md
@@ -1066,6 +1066,8 @@ Exemplo de configuração para cálculo **PERIODIC**, sessão diária, com preç
    "lta_width": 1,
    "ltb_width": 1,
    "extend_right": true,
+   "extend_bars": 20,
+   "label_offset": 50,
    "show_labels": true,
    "stability_bars": 2,
    "min_distance": 5,
@@ -1083,6 +1085,8 @@ Exemplo de configuração para cálculo **PERIODIC**, sessão diária, com preç
 ```
 - `left`/`right`: número de velas usadas para detectar fractais.
 - `extend_right`: projeta a linha no futuro.
+- `extend_bars`: quantidade de barras usadas para projeção.
+- `label_offset`: deslocamento vertical dos rótulos, em pontos.
 - `show_labels`: mostra preços nas linhas.
 - `stability_bars`: número mínimo de candles que o par de fractais deve permanecer igual para ser confirmado.
 - `min_distance`: distância mínima em barras entre os fractais conectados.


### PR DESCRIPTION
## Summary
- adicionar parâmetros de `extend_bars` e `label_offset` nas configurações de trendline
- aprimorar `DrawLines` para usar projeção via tempo de barra e remover shift negativo
- refinar cálculo de desvio em `CalculateLinePrice`
- tornar `ValidateLineWithMTF` constante
- melhorar liberação de handles na inicialização
- atualizar exemplos e documentação

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f26263e388320b8f682dc81c1e979