### PR TITLE
Add ATR period and psychological step parameters

### DIFF
--- a/TF_CTX/config_manager.mqh
+++ b/TF_CTX/config_manager.mqh
@@ -802,11 +802,15 @@ STimeframeConfig CConfigManager::ParseTimeframeConfig(CJAVal *tf_config)
              if(p.label_offset<=0) p.label_offset=50.0;
              p.stability_bars=(int)pa["stability_bars"].ToInt();
               p.min_distance=(int)pa["min_distance"].ToInt();
-             p.validate_mtf=pa["validate_mtf"].ToBool();
-             string mtf=pa["mtf_timeframe"].ToStr();
-             if(StringLen(mtf)>0) p.mtf_timeframe=StringToTimeframe(mtf);
-             CJAVal *sc=pa["scoring"];
-             p.weights=ParseScoreWeights(sc);
+            p.validate_mtf=pa["validate_mtf"].ToBool();
+            string mtf=pa["mtf_timeframe"].ToStr();
+            if(StringLen(mtf)>0) p.mtf_timeframe=StringToTimeframe(mtf);
+            if(pa["atr_period"]!=NULL)
+               p.atr_period=(int)pa["atr_period"].ToInt();
+            if(pa["psych_step"]!=NULL)
+               p.psych_step=pa["psych_step"].ToDbl();
+            CJAVal *sc=pa["scoring"];
+            p.weights=ParseScoreWeights(sc);
              CJAVal *uc=pa["update_control"];
              p.update_control=ParseUpdateParams(uc);
 

--- a/TF_CTX/config_types.mqh
+++ b/TF_CTX/config_types.mqh
@@ -199,7 +199,9 @@ public:
   bool validate_mtf;             // validar com timeframe superior
   ENUM_TIMEFRAMES mtf_timeframe; // timeframe para validação
   ScoreWeights    weights;       // pesos para o algoritmo de scoring
-  
+  int             atr_period;    // período do ATR usado para contexto
+  double          psych_step;    // passo para níveis psicológicos
+
   UpdateParams   update_control;
   CTrendLineConfig()
   {
@@ -224,6 +226,8 @@ public:
     validate_mtf = false;
     mtf_timeframe = PERIOD_H1;
     weights = ScoreWeights();
+    atr_period = 14;
+    psych_step = 100.0;
     update_control = UpdateParams();
   }
 };

--- a/TF_CTX/priceaction/trendline/trendline.mqh
+++ b/TF_CTX/priceaction/trendline/trendline.mqh
@@ -100,6 +100,8 @@ private:
   int             m_min_distance;
   bool            m_validate_mtf;
   ENUM_TIMEFRAMES m_mtf_timeframe;
+  int             m_atr_period;
+  double          m_psych_step;
 
   FractalCache    m_low_cache;
   FractalCache    m_high_cache;
@@ -204,9 +206,11 @@ CTrendLine::CTrendLine()
    m_confirm_bars = 2;
    m_min_distance = 5;
    m_validate_mtf = false;
-   m_mtf_timeframe = PERIOD_H1;
-   m_need_redraw = true;
-   m_weights = ScoreWeights();
+  m_mtf_timeframe = PERIOD_H1;
+  m_need_redraw = true;
+  m_weights = ScoreWeights();
+  m_atr_period = 14;
+  m_psych_step = 100.0;
 
    m_low_cache.confirmation_bars = m_confirm_bars;
    m_high_cache.confirmation_bars = m_confirm_bars;
@@ -262,6 +266,8 @@ bool CTrendLine::Init(string symbol, ENUM_TIMEFRAMES timeframe, CTrendLineConfig
   m_validate_mtf = config.validate_mtf;
   m_mtf_timeframe = config.mtf_timeframe;
   m_weights = config.weights;
+  m_atr_period = config.atr_period;
+  m_psych_step = config.psych_step;
   m_update_ctrl.params = config.update_control;
    
    // Criar nomes únicos para objetos
@@ -335,7 +341,7 @@ void CTrendLine::ReleaseFractalsHandle()
 //+------------------------------------------------------------------+
 bool CTrendLine::CreateATRHandle()
 {
-   m_atr_handle = iATR(m_symbol, m_timeframe, 14);
+   m_atr_handle = iATR(m_symbol, m_timeframe, m_atr_period);
    if(m_atr_handle == INVALID_HANDLE)
    {
       Print("ERRO: Falha ao criar handle ATR para ", m_symbol);
@@ -944,7 +950,7 @@ double CTrendLine::ComputeTimeValidity(SFractalPoint &p_old, SFractalPoint &p_re
 
 double CTrendLine::ComputePsychologicalLevel(SFractalPoint &p_old, SFractalPoint &p_recent)
 {
-   double step=100.0;
+   double step=m_psych_step;
    double diff1=MathAbs(p_old.price-MathRound(p_old.price/step)*step);
    double diff2=MathAbs(p_recent.price-MathRound(p_recent.price/step)*step);
    double diff=(diff1+diff2)/2.0;

--- a/config.json
+++ b/config.json
@@ -134,6 +134,8 @@
                "period": 20,
                "left": 3,
                "right": 3,
+               "atr_period": 14,
+               "psych_step": 1000,
                "confirm_bars": 2,
                "draw_lta": true,
                "draw_ltb": true,

--- a/documentation.md
+++ b/documentation.md
@@ -1057,6 +1057,8 @@ Exemplo de configuração para cálculo **PERIODIC**, sessão diária, com preç
    "period": 20,
    "left": 3,
    "right": 3,
+   "atr_period": 14,
+   "psych_step": 1000,
    "draw_lta": true,
    "draw_ltb": true,
    "lta_color": "Lime",
@@ -1092,6 +1094,8 @@ Exemplo de configuração para cálculo **PERIODIC**, sessão diária, com preç
 - `min_distance`: distância mínima em barras entre os fractais conectados.
 - `validate_mtf`: habilita verificação em um timeframe superior.
 - `mtf_timeframe`: timeframe utilizado para validação.
+- `atr_period`: período do ATR usado para avaliar volatilidade.
+- `psych_step`: distância em pontos para níveis psicológicos.
 - `update_control`: parâmetros do sistema de atualização condicional.
   - `min_update_interval`: intervalo mínimo entre atualizações completas (segundos).
   - `fractal_check_interval`: frequência para checar novos fractais.


### PR DESCRIPTION
## Summary
- extend `CTrendLineConfig` to include `atr_period` and `psych_step`
- store these values inside `CTrendLine` and apply in ATR creation and psychological level calculation
- parse new parameters in `config_manager`
- document new options and update example config
- provide sample values in `config.json`

## Testing
- `jq '.' config.json > /dev/null`

------
https://chatgpt.com/codex/tasks/task_e_685f294746b88320997120a230268591