### PR TITLE
Add statistical validation for trendline

### DIFF
--- a/TF_CTX/priceaction/trendline/trendline.mqh
+++ b/TF_CTX/priceaction/trendline/trendline.mqh
@@ -13,6 +13,7 @@ const int TRENDLINE_MAX_FRACTALS = 50;
 // Pontuação mínima para aceitar uma linha candidata
 const double TRENDLINE_SCORE_THRESHOLD = 40.0;
 const double TRENDLINE_PI = 3.14159265358979323846;
+const double TRENDLINE_RSQUARED_THRESHOLD = 0.7;
 
 // Estrutura para armazenar um ponto fractal
 struct SFractalPoint
@@ -142,10 +143,12 @@ private:
   bool            CheckLowFractal(int index,double value);
   int             CountAlignedFractals(const SFractalPoint &p_old, const SFractalPoint &p_recent, const SFractalPoint &fracs[]);
   void            UpdateTrendState(TrendLineState &state, SFractalPoint &p_old, SFractalPoint &p_recent);
-   bool            ValidateLineWithMTF(const SFractalPoint &p_old, const SFractalPoint &p_recent);
-   void            ConditionalUpdate(ENUM_UPDATE_TRIGGER trigger);
-   bool            ShouldUpdate(ENUM_UPDATE_TRIGGER &trigger);
-   void            ValidateLineCorrections();
+  double          CalculateRSquared(const SFractalPoint &p_old, const SFractalPoint &p_recent);
+  bool            ValidateLineStatistically(const SFractalPoint &p_old, const SFractalPoint &p_recent);
+  bool            ValidateLineWithMTF(const SFractalPoint &p_old, const SFractalPoint &p_recent);
+  void            ConditionalUpdate(ENUM_UPDATE_TRIGGER trigger);
+  bool            ShouldUpdate(ENUM_UPDATE_TRIGGER &trigger);
+  void            ValidateLineCorrections();
 public:
    CTrendLine();
    ~CTrendLine();
@@ -535,11 +538,13 @@ void CTrendLine::FindTrendLines()
            double score = ScorePair(lows_all[i], lows_all[j]);
            if(score < TRENDLINE_SCORE_THRESHOLD)
               continue;
-            if(score > best_score)
-            {
-               best_score = score;
-               best_p1 = lows_all[i];
-               best_p2 = lows_all[j];
+           if(!ValidateLineStatistically(lows_all[i], lows_all[j]))
+              continue;
+           if(score > best_score)
+           {
+              best_score = score;
+              best_p1 = lows_all[i];
+              best_p2 = lows_all[j];
             }
          }
       }
@@ -620,11 +625,13 @@ void CTrendLine::FindTrendLines()
            double score = ScorePair(highs_all[i], highs_all[j]);
            if(score < TRENDLINE_SCORE_THRESHOLD)
               continue;
-            if(score > best_score)
-            {
-               best_score = score;
-               best_p1 = highs_all[i];
-               best_p2 = highs_all[j];
+           if(!ValidateLineStatistically(highs_all[i], highs_all[j]))
+              continue;
+           if(score > best_score)
+           {
+              best_score = score;
+              best_p1 = highs_all[i];
+              best_p2 = highs_all[j];
             }
          }
       }
@@ -954,6 +961,46 @@ double CTrendLine::ScorePair(SFractalPoint &p_old, SFractalPoint &p_recent)
    score *= (1.0 + (q.mtf_alignment       * m_weights.mtf_weight)        / 100.0);
 
    return MathMin(score,100.0);
+}
+
+double CTrendLine::CalculateRSquared(const SFractalPoint &p_old, const SFractalPoint &p_recent)
+{
+   int start = MathMin(p_old.bar_index, p_recent.bar_index);
+   int end   = MathMax(p_old.bar_index, p_recent.bar_index);
+   double sum_x=0.0, sum_y=0.0, sum_x2=0.0, sum_y2=0.0, sum_xy=0.0;
+   int count=0;
+
+   for(int i=start; i<=end; i++)
+   {
+      double x = CalculateLinePrice(p_old, p_recent, i);
+      if(x==EMPTY_VALUE)
+         continue;
+      double y = iClose(m_symbol, m_timeframe, i);
+      sum_x+=x;
+      sum_y+=y;
+      sum_x2+=x*x;
+      sum_y2+=y*y;
+      sum_xy+=x*y;
+      count++;
+   }
+
+   if(count<2)
+      return 0.0;
+
+   double num = count*sum_xy - sum_x*sum_y;
+   double den1 = count*sum_x2 - sum_x*sum_x;
+   double den2 = count*sum_y2 - sum_y*sum_y;
+   if(den1<=0.0 || den2<=0.0)
+      return 0.0;
+
+   double r = num / MathSqrt(den1*den2);
+   return r*r;
+}
+
+bool CTrendLine::ValidateLineStatistically(const SFractalPoint &p_old, const SFractalPoint &p_recent)
+{
+   double r2 = CalculateRSquared(p_old, p_recent);
+   return (r2 >= TRENDLINE_RSQUARED_THRESHOLD);
 }
 
 //--- Cálculo dos fatores individuais ---


### PR DESCRIPTION
## Summary
- extend `CTrendLine` with statistical validation helpers
- require line candidates to pass statistical check during detection

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f750833c083208216522425f038f0