### PR TITLE
Allow custom score threshold for trend lines

### DIFF
--- a/TF_CTX/config_manager.mqh
+++ b/TF_CTX/config_manager.mqh
@@ -811,14 +811,16 @@ STimeframeConfig CConfigManager::ParseTimeframeConfig(CJAVal *tf_config)
             if(StringLen(mtf)>0) p.mtf_timeframe=StringToTimeframe(mtf);
             if(pa["atr_period"]!=NULL)
                p.atr_period=(int)pa["atr_period"].ToInt();
-            if(pa["psych_step"]!=NULL)
-               p.psych_step=pa["psych_step"].ToDbl();
-           if(pa["min_angle_deg"]!=NULL)
-              p.min_angle_deg=pa["min_angle_deg"].ToDbl();
-           CJAVal *sc=pa["scoring"];
-            p.weights=ParseScoreWeights(sc);
-             CJAVal *uc=pa["update_control"];
-             p.update_control=ParseUpdateParams(uc);
+           if(pa["psych_step"]!=NULL)
+              p.psych_step=pa["psych_step"].ToDbl();
+          if(pa["min_angle_deg"]!=NULL)
+             p.min_angle_deg=pa["min_angle_deg"].ToDbl();
+          if(pa["score_threshold"]!=NULL)
+             p.score_threshold=pa["score_threshold"].ToDbl();
+          CJAVal *sc=pa["scoring"];
+           p.weights=ParseScoreWeights(sc);
+            CJAVal *uc=pa["update_control"];
+            p.update_control=ParseUpdateParams(uc);
 
               pacfg=p;
              }

--- a/TF_CTX/config_types.mqh
+++ b/TF_CTX/config_types.mqh
@@ -203,6 +203,7 @@ public:
   int             atr_period;    // período do ATR usado para contexto
   double          psych_step;    // passo para níveis psicológicos
   double          min_angle_deg; // ângulo mínimo aceitável
+  double          score_threshold; // pontuação mínima para aceitar a linha
 
   UpdateParams   update_control;
   CTrendLineConfig()
@@ -232,6 +233,7 @@ public:
     atr_period = 14;
     psych_step = 100.0;
     min_angle_deg = 10.0;
+    score_threshold = 40.0;
     update_control = UpdateParams();
   }
 };

--- a/TF_CTX/priceaction/trendline/trendline.mqh
+++ b/TF_CTX/priceaction/trendline/trendline.mqh
@@ -10,8 +10,8 @@
 #include "trendline_defs.mqh"
 
 const int TRENDLINE_MAX_FRACTALS = 50;
-// Pontuação mínima para aceitar uma linha candidata
-const double TRENDLINE_SCORE_THRESHOLD = 40.0;
+// Pontuação mínima padrão para aceitar uma linha candidata
+const double TRENDLINE_DEFAULT_SCORE_THRESHOLD = 40.0;
 const double TRENDLINE_PI = 3.14159265358979323846;
 
 // Estrutura para armazenar um ponto fractal
@@ -106,6 +106,7 @@ private:
   int             m_atr_period;
   double          m_psych_step;
   double          m_min_angle_deg;
+  double          m_score_threshold;
 
   FractalCache    m_low_cache;
   FractalCache    m_high_cache;
@@ -223,6 +224,7 @@ CTrendLine::CTrendLine()
   m_atr_period = 14;
   m_psych_step = 100.0;
   m_min_angle_deg = 10.0;
+  m_score_threshold = TRENDLINE_DEFAULT_SCORE_THRESHOLD;
 
    m_low_cache.confirmation_bars = m_confirm_bars;
    m_high_cache.confirmation_bars = m_confirm_bars;
@@ -282,6 +284,7 @@ bool CTrendLine::Init(string symbol, ENUM_TIMEFRAMES timeframe, CTrendLineConfig
   m_atr_period = config.atr_period;
   m_psych_step = config.psych_step;
   m_min_angle_deg = config.min_angle_deg;
+  m_score_threshold = config.score_threshold;
   m_update_ctrl.params = config.update_control;
    
    // Criar nomes únicos para objetos
@@ -537,8 +540,8 @@ void CTrendLine::FindTrendLines()
               continue;
 
            double score = ScorePair(lows_all[i], lows_all[j]);
-           if(score < TRENDLINE_SCORE_THRESHOLD)
-              continue;
+           if(score < m_score_threshold)
+             continue;
             if(score > best_score)
             {
                best_score = score;
@@ -622,8 +625,8 @@ void CTrendLine::FindTrendLines()
               continue;
 
            double score = ScorePair(highs_all[i], highs_all[j]);
-           if(score < TRENDLINE_SCORE_THRESHOLD)
-              continue;
+           if(score < m_score_threshold)
+             continue;
             if(score > best_score)
             {
                best_score = score;

--- a/config.json
+++ b/config.json
@@ -138,6 +138,7 @@
                "psych_step": 500,
                "confirm_bars": 2,
                "min_angle_deg": 10,
+               "score_threshold": 45,
                "min_fractals": 3,
                "draw_lta": true,
                "draw_ltb": true,

--- a/documentation.md
+++ b/documentation.md
@@ -1060,6 +1060,7 @@ Exemplo de configuração para cálculo **PERIODIC**, sessão diária, com preç
    "atr_period": 14,
    "psych_step": 1000,
    "min_angle_deg": 10,
+   "score_threshold": 40,
    "draw_lta": true,
    "draw_ltb": true,
    "lta_color": "Lime",
@@ -1098,6 +1099,7 @@ Exemplo de configuração para cálculo **PERIODIC**, sessão diária, com preç
 - `atr_period`: período do ATR usado para avaliar volatilidade.
 - `psych_step`: distância em pontos para níveis psicológicos.
 - `min_angle_deg`: ângulo mínimo em graus para aceitar uma linha.
+- `score_threshold`: nota mínima em `ScorePair` para validar a linha.
 - `update_control`: parâmetros do sistema de atualização condicional.
   - `min_update_interval`: intervalo mínimo entre atualizações completas (segundos).
   - `fractal_check_interval`: frequência para checar novos fractais.


### PR DESCRIPTION
## Summary
- add `score_threshold` to `CTrendLineConfig`
- parse new parameter from JSON config
- expose member in `CTrendLine` and respect during scoring
- document new option and update sample config

## Testing
- `echo "No tests"`

------
https://chatgpt.com/codex/tasks/task_e_6860670274888320b0374786f666d971