### PR TITLE
Fix context timeframe parsing

### DIFF
--- a/PA_WIN.mq5
+++ b/PA_WIN.mq5
@@ -125,33 +125,43 @@ void ExecuteOnNewBar()
 
    string configured_symbol = "WIN$N"; // Usar símbolo fixo do JSON
 
-   // Obter contexto D1 se habilitado
-   TF_CTX *D1_ctx = g_config_manager.GetContext(configured_symbol, PERIOD_D1);
-   if (D1_ctx != NULL)
-   {
-      D1_ctx.Update();
+   // Atualizar automaticamente todos os contextos carregados do JSON
+   TF_CTX *contexts[];
+   ENUM_TIMEFRAMES tfs[];
+   int count = g_config_manager.GetSymbolContexts(configured_symbol, contexts, tfs);
 
-      Print("=== Contexto D1 ===");
-      for (int i = 1; i < 2; i++)
+   if(count==0)
+   {
+      Print("AVISO: Nenhum contexto encontrado para símbolo: ", configured_symbol);
+      return;
+   }
+
+   for(int i=0;i<count;i++)
+   {
+      TF_CTX *ctx = contexts[i];
+      ENUM_TIMEFRAMES tf = tfs[i];
+
+      if(ctx==NULL)
+         continue;
+
+      ctx.Update();
+
+      if(tf==PERIOD_D1)
       {
-         double ema9  = D1_ctx.GetIndicatorValue("ema9", i);
-         double ema21 = D1_ctx.GetIndicatorValue("ema21", i);
-         Print("EMA9 D1 Shift: ", i, " = ", ema9);
-         Print("EMA21 D1 Shift: ", i, " = ", ema21);
+         Print("=== Contexto D1 ===");
+         for (int j = 1; j < 2; j++)
+         {
+            double ema9  = ctx.GetIndicatorValue("ema9", j);
+            double ema21 = ctx.GetIndicatorValue("ema21", j);
+            Print("EMA9 D1 Shift: ", j, " = ", ema9);
+            Print("EMA21 D1 Shift: ", j, " = ", ema21);
+         }
       }
-   }
-   else
-   {
-      Print("AVISO: Contexto D1 não encontrado para símbolo: ", configured_symbol);
-   }
-
-   // Contexto H1 com PriceAction
-   TF_CTX *H1_ctx = g_config_manager.GetContext(configured_symbol, PERIOD_H1);
-   if(H1_ctx!=NULL)
-   {
-      H1_ctx.Update();
-      double lta = H1_ctx.GetPriceActionValue("swing_lines",0);
-      Print("LTA H1 atual: ", lta);
+      else if(tf==PERIOD_H1)
+      {
+         double lta = ctx.GetPriceActionValue("swing_lines",0);
+         Print("LTA H1 atual: ", lta);
+      }
    }
 }
 

--- a/PA_WIN.mq5
+++ b/PA_WIN.mq5
@@ -145,13 +145,13 @@ void ExecuteOnNewBar()
       Print("AVISO: Contexto D1 não encontrado para símbolo: ", configured_symbol);
    }
 
-   // Contexto H4 com PriceAction
-   TF_CTX *H4_ctx = g_config_manager.GetContext(configured_symbol, PERIOD_H4);
-   if(H4_ctx!=NULL)
+   // Contexto H1 com PriceAction
+   TF_CTX *H1_ctx = g_config_manager.GetContext(configured_symbol, PERIOD_H1);
+   if(H1_ctx!=NULL)
    {
-      H4_ctx.Update();
-      double lta = H4_ctx.GetPriceActionValue("swing_lines",0);
-      Print("LTA H4 atual: ", lta);
+      H1_ctx.Update();
+      double lta = H1_ctx.GetPriceActionValue("swing_lines",0);
+      Print("LTA H1 atual: ", lta);
    }
 }
 

--- a/TF_CTX/config_manager.mqh
+++ b/TF_CTX/config_manager.mqh
@@ -53,6 +53,7 @@ public:
     TF_CTX *GetContext(string symbol, ENUM_TIMEFRAMES timeframe);
     bool IsContextEnabled(string symbol, ENUM_TIMEFRAMES timeframe);
     void GetConfiguredSymbols(string &symbols[]);
+    int GetSymbolContexts(string symbol, TF_CTX *&contexts[], ENUM_TIMEFRAMES &timeframes[]);
     void Cleanup();
     bool IsInitialized() const { return m_initialized; }
 };
@@ -397,6 +398,32 @@ void CConfigManager::GetConfiguredSymbols(string &symbols[])
     {
         symbols[i] = m_symbols[i];
     }
+}
+
+//+------------------------------------------------------------------+
+//| Obter todos os contextos de um símbolo                           |
+//+------------------------------------------------------------------+
+int CConfigManager::GetSymbolContexts(string symbol, TF_CTX *&contexts[], ENUM_TIMEFRAMES &timeframes[])
+{
+    ArrayResize(contexts, 0);
+    ArrayResize(timeframes, 0);
+
+    for (int i = 0; i < ArraySize(m_context_keys); i++)
+    {
+        string key = m_context_keys[i];
+        if (StringFind(key, symbol + "_") == 0)
+        {
+            int pos = ArraySize(contexts);
+            ArrayResize(contexts, pos + 1);
+            ArrayResize(timeframes, pos + 1);
+            contexts[pos] = m_contexts[i];
+
+            string tf_str = StringSubstr(key, StringLen(symbol) + 1);
+            timeframes[pos] = StringToTimeframe(tf_str);
+        }
+    }
+
+    return ArraySize(contexts);
 }
 
 //+------------------------------------------------------------------+

--- a/TF_CTX/config_manager.mqh
+++ b/TF_CTX/config_manager.mqh
@@ -37,7 +37,7 @@ private:
     ENUM_VWAP_PRICE_TYPE StringToVWAPPriceType(string type_str);
     ENUM_LINE_STYLE StringToLineStyle(string style_str);
     color StringToColor(string color_str);
-    STimeframeConfig ParseTimeframeConfig(CJAVal *tf_config);
+    STimeframeConfig ParseTimeframeConfig(CJAVal *tf_config, ENUM_TIMEFRAMES tf);
     string CreateContextKey(string symbol, ENUM_TIMEFRAMES tf);
     bool TestJSONParsing();
     
@@ -313,19 +313,19 @@ bool CConfigManager::CreateContexts()
                 continue;
             }
 
-            STimeframeConfig config = ParseTimeframeConfig(tf_config);
+            ENUM_TIMEFRAMES tf = StringToTimeframe(tf_str);
+            if (tf == PERIOD_CURRENT)
+            {
+                Print("ERRO: TimeFrame inválido: ", tf_str);
+                continue;
+            }
+
+            STimeframeConfig config = ParseTimeframeConfig(tf_config, tf);
             Print("TimeFrame ", tf_str, " - Enabled: ", config.enabled, " NumCandles: ", config.num_candles);
 
             if (!config.enabled)
             {
                 Print("TimeFrame ", tf_str, " está desabilitado");
-                continue;
-            }
-
-            ENUM_TIMEFRAMES tf = StringToTimeframe(tf_str);
-            if (tf == PERIOD_CURRENT)
-            {
-                Print("ERRO: TimeFrame inválido: ", tf_str);
                 continue;
             }
 
@@ -569,7 +569,7 @@ color CConfigManager::StringToColor(string color_str)
 //+------------------------------------------------------------------+
 //| Fazer parse da configuração do timeframe                        |
 //+------------------------------------------------------------------+
-STimeframeConfig CConfigManager::ParseTimeframeConfig(CJAVal *tf_config)
+STimeframeConfig CConfigManager::ParseTimeframeConfig(CJAVal *tf_config, ENUM_TIMEFRAMES ctx_tf)
 {
     STimeframeConfig config;
     
@@ -747,6 +747,10 @@ STimeframeConfig CConfigManager::ParseTimeframeConfig(CJAVal *tf_config)
              p.fractal_tf=StringToTimeframe(pa["fractal_tf"].ToStr());
              p.detail_tf=StringToTimeframe(pa["detail_tf"].ToStr());
              p.alert_tf=StringToTimeframe(pa["alert_tf"].ToStr());
+
+             if(p.fractal_tf==PERIOD_CURRENT) p.fractal_tf=ctx_tf;
+             if(p.detail_tf==PERIOD_CURRENT)  p.detail_tf=ctx_tf;
+             if(p.alert_tf==PERIOD_CURRENT)   p.alert_tf=ctx_tf;
              pcfg=p;
             }
 

--- a/config.json
+++ b/config.json
@@ -124,7 +124,7 @@
             }
          ]
       },
-      "H4": {
+      "H1": {
          "enabled": true,
          "num_candles": 18,
          "indicators": [
@@ -192,7 +192,7 @@
                "period": 20,
                "left": 3,
                "right": 3,
-               "fractal_tf": "H4",
+               "fractal_tf": "H1",
                "detail_tf": "H1",
                "alert_tf": "H1",
                "draw_lta": true,

--- a/documentation.md
+++ b/documentation.md
@@ -139,7 +139,7 @@ Esta seção detalha as principais funções e classes encontradas no código do
 
 - **`ExecuteOnNewBar()`**
   - **Assinatura**: `void ExecuteOnNewBar()`
-  - **Descrição simplificada**: Contém a lógica a ser executada quando um novo candle é detectado. Atualmente, obtém e atualiza o contexto D1 para o símbolo "WIN$N" e imprime os valores das EMAs 9 e 21.
+  - **Descrição simplificada**: Contém a lógica a ser executada quando um novo candle é detectado. Agora os contextos configurados no JSON para o símbolo "WIN$N" são obtidos de forma dinâmica. Cada contexto é atualizado automaticamente e são impressas informações específicas, como as EMAs no timeframe D1 ou a linha de tendência do H1.
   - **Parâmetros**: Nenhum.
   - **Valor de retorno**: Nenhum.
 


### PR DESCRIPTION
## Summary
- change timeframe key in config.json from H4 to H1
- adjust EA to request the H1 context
- set default timeframe for price actions when not provided

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6861a28ae1d08320927c91bcfc2a1733