### PR TITLE
Add SupRes price action and guide

### DIFF
--- a/TF_CTX/config_manager.mqh
+++ b/TF_CTX/config_manager.mqh
@@ -752,8 +752,8 @@ STimeframeConfig CConfigManager::ParseTimeframeConfig(CJAVal *tf_config, ENUM_TI
 
            CPriceActionConfig *pcfg=NULL;
            string type=pa["type"].ToStr();
-           if(type=="TRENDLINE")
-             {
+          if(type=="TRENDLINE")
+            {
               CTrendLineConfig *p=new CTrendLineConfig();
               p.name=pa["name"].ToStr();
               p.type=type;
@@ -778,6 +778,27 @@ STimeframeConfig CConfigManager::ParseTimeframeConfig(CJAVal *tf_config, ENUM_TI
              if(p.fractal_tf==PERIOD_CURRENT) p.fractal_tf=ctx_tf;
              if(p.detail_tf==PERIOD_CURRENT)  p.detail_tf=ctx_tf;
              if(p.alert_tf==PERIOD_CURRENT)   p.alert_tf=ctx_tf;
+             pcfg=p;
+            }
+          else if(type=="SUPRES")
+            {
+             CSupResConfig *p=new CSupResConfig();
+             p.name=pa["name"].ToStr();
+             p.type=type;
+             p.enabled=pa["enabled"].ToBool();
+             p.period=(int)pa["period"].ToInt();
+             p.draw_sup=pa["draw_sup"].ToBool();
+             p.draw_res=pa["draw_res"].ToBool();
+             p.sup_color=StringToColor(pa["sup_color"].ToStr());
+             p.res_color=StringToColor(pa["res_color"].ToStr());
+             p.sup_style=StringToLineStyle(pa["sup_style"].ToStr());
+             p.res_style=StringToLineStyle(pa["res_style"].ToStr());
+             p.sup_width=(int)pa["sup_width"].ToInt();
+             p.res_width=(int)pa["res_width"].ToInt();
+             p.extend_right=pa["extend_right"].ToBool();
+             p.show_labels=pa["show_labels"].ToBool();
+             p.alert_tf=StringToTimeframe(pa["alert_tf"].ToStr());
+             if(p.alert_tf==PERIOD_CURRENT) p.alert_tf=ctx_tf;
              pcfg=p;
             }
 

--- a/TF_CTX/config_types.mqh
+++ b/TF_CTX/config_types.mqh
@@ -154,13 +154,39 @@ public:
    ENUM_TIMEFRAMES fractal_tf;
    ENUM_TIMEFRAMES detail_tf;
    ENUM_TIMEFRAMES alert_tf;
-   CTrendLineConfig()
-     {
+  CTrendLineConfig()
+    {
       period=20; left=3; right=3; draw_lta=true; draw_ltb=true;
       lta_color=clrGreen; ltb_color=clrRed;
       lta_style=STYLE_SOLID; ltb_style=STYLE_SOLID;
       lta_width=1; ltb_width=1; extend_right=true; show_labels=false;
       fractal_tf=PERIOD_H4; detail_tf=PERIOD_H1; alert_tf=PERIOD_H1;
+    }
+  };
+
+//--- Support/Resistance configuration
+class CSupResConfig : public CPriceActionConfig
+  {
+public:
+   int             period;
+   bool            draw_sup;
+   bool            draw_res;
+   color           sup_color;
+   color           res_color;
+   ENUM_LINE_STYLE sup_style;
+   ENUM_LINE_STYLE res_style;
+   int             sup_width;
+   int             res_width;
+   bool            extend_right;
+   bool            show_labels;
+   ENUM_TIMEFRAMES alert_tf;
+   CSupResConfig()
+     {
+      period=50; draw_sup=true; draw_res=true;
+      sup_color=clrBlue; res_color=clrRed;
+      sup_style=STYLE_SOLID; res_style=STYLE_SOLID;
+      sup_width=1; res_width=1; extend_right=true; show_labels=false;
+      alert_tf=PERIOD_H1;
      }
   };
 

--- a/TF_CTX/factories/priceaction_factory.mqh
+++ b/TF_CTX/factories/priceaction_factory.mqh
@@ -2,6 +2,7 @@
 #define __PRICEACTION_FACTORY_MQH__
 
 #include "../priceaction/trendline/trendline.mqh"
+#include "../priceaction/sup_res/sup_res.mqh"
 #include "../config_types.mqh"
 
 // Creator function signature
@@ -24,8 +25,9 @@ private:
       RegisterDefaults();
      }
 
-   void RegisterDefaults();
-   static CPriceActionBase* CreateTrendLine(string symbol, ENUM_TIMEFRAMES tf, CPriceActionConfig *cfg);
+  void RegisterDefaults();
+  static CPriceActionBase* CreateTrendLine(string symbol, ENUM_TIMEFRAMES tf, CPriceActionConfig *cfg);
+  static CPriceActionBase* CreateSupRes(string symbol, ENUM_TIMEFRAMES tf, CPriceActionConfig *cfg);
 
 public:
    static CPriceActionFactory* Instance()
@@ -70,6 +72,7 @@ CPriceActionFactory* CPriceActionFactory::s_instance = NULL;
 void CPriceActionFactory::RegisterDefaults()
   {
    Register("TRENDLINE", CreateTrendLine);
+   Register("SUPRES",   CreateSupRes);
   }
 
 CPriceActionBase* CPriceActionFactory::CreateTrendLine(string symbol, ENUM_TIMEFRAMES tf, CPriceActionConfig *cfg)
@@ -78,6 +81,18 @@ CPriceActionBase* CPriceActionFactory::CreateTrendLine(string symbol, ENUM_TIMEF
    if(c==NULL)
       return NULL;
    CTrendLine *pa = new CTrendLine();
+   if(pa!=NULL && pa.Init(symbol, tf, *c))
+      return pa;
+  delete pa;
+  return NULL;
+  }
+
+CPriceActionBase* CPriceActionFactory::CreateSupRes(string symbol, ENUM_TIMEFRAMES tf, CPriceActionConfig *cfg)
+  {
+   CSupResConfig *c = (CSupResConfig*)cfg;
+   if(c==NULL)
+      return NULL;
+   CSupRes *pa = new CSupRes();
    if(pa!=NULL && pa.Init(symbol, tf, *c))
       return pa;
    delete pa;

--- a/TF_CTX/priceaction/sup_res/sup_res.mqh
+++ b/TF_CTX/priceaction/sup_res/sup_res.mqh
@@ -1,0 +1,245 @@
+//+------------------------------------------------------------------+
+//|                                                sup_res.mqh       |
+//|  Simple support and resistance lines                             |
+//+------------------------------------------------------------------+
+#ifndef __SUP_RES_MQH__
+#define __SUP_RES_MQH__
+
+#include "../priceaction_base.mqh"
+#include "sup_res_defs.mqh"
+#include "../../config_types.mqh"
+
+class CSupRes : public CPriceActionBase
+  {
+private:
+   string          m_symbol;
+   ENUM_TIMEFRAMES m_timeframe;
+   int             m_period;
+   bool            m_draw_sup;
+   bool            m_draw_res;
+   color           m_sup_color;
+   color           m_res_color;
+   ENUM_LINE_STYLE m_sup_style;
+   ENUM_LINE_STYLE m_res_style;
+   int             m_sup_width;
+   int             m_res_width;
+   bool            m_extend_right;
+   bool            m_show_labels;
+   ENUM_TIMEFRAMES m_alert_tf;
+   bool            m_ready;
+   double          m_sup_val;
+   double          m_res_val;
+   bool            m_breakdown;
+   bool            m_breakup;
+   string          m_obj_sup;
+   string          m_obj_res;
+
+   void            DrawLine(string name,double price,color col,ENUM_LINE_STYLE st,int width);
+
+public:
+                     CSupRes();
+                    ~CSupRes();
+
+   bool             Init(string symbol,ENUM_TIMEFRAMES timeframe,CSupResConfig &cfg);
+   virtual bool     Init(string symbol,ENUM_TIMEFRAMES timeframe,int period);
+   virtual double   GetValue(int shift=0); // returns support value
+   virtual bool     CopyValues(int shift,int count,double &buffer[]);
+   virtual bool     IsReady();
+   virtual bool     Update();
+
+   double           GetSupportValue(int shift=0);
+   double           GetResistanceValue(int shift=0);
+   bool             IsBreakdown();
+   bool             IsBreakup();
+  };
+
+//+------------------------------------------------------------------+
+//| Constructor                                                       |
+//+------------------------------------------------------------------+
+CSupRes::CSupRes()
+  {
+   m_symbol="";
+   m_timeframe=PERIOD_CURRENT;
+   m_period=50;
+   m_draw_sup=true;
+   m_draw_res=true;
+   m_sup_color=clrBlue;
+   m_res_color=clrRed;
+   m_sup_style=STYLE_SOLID;
+   m_res_style=STYLE_SOLID;
+   m_sup_width=1;
+   m_res_width=1;
+   m_extend_right=true;
+   m_show_labels=false;
+   m_alert_tf=PERIOD_CURRENT;
+   m_ready=false;
+   m_sup_val=0.0;
+   m_res_val=0.0;
+   m_breakdown=false;
+   m_breakup=false;
+   m_obj_sup="";
+   m_obj_res="";
+  }
+
+//+------------------------------------------------------------------+
+//| Destructor                                                        |
+//+------------------------------------------------------------------+
+CSupRes::~CSupRes()
+  {
+   if(StringLen(m_obj_sup)>0)
+      ObjectDelete(0,m_obj_sup);
+   if(StringLen(m_obj_res)>0)
+      ObjectDelete(0,m_obj_res);
+  }
+
+//+------------------------------------------------------------------+
+//| Draw horizontal line                                              |
+//+------------------------------------------------------------------+
+void CSupRes::DrawLine(string name,double price,color col,ENUM_LINE_STYLE st,int width)
+  {
+   if(ObjectFind(0,name)<0)
+      ObjectCreate(0,name,OBJ_HLINE,0,0,price);
+   else
+      ObjectSetDouble(0,name,OBJPROP_PRICE,price);
+   ObjectSetInteger(0,name,OBJPROP_COLOR,col);
+   ObjectSetInteger(0,name,OBJPROP_STYLE,st);
+   ObjectSetInteger(0,name,OBJPROP_WIDTH,width);
+   ObjectSetInteger(0,name,OBJPROP_RAY_RIGHT,m_extend_right);
+  }
+
+//+------------------------------------------------------------------+
+//| Init using configuration                                          |
+//+------------------------------------------------------------------+
+bool CSupRes::Init(string symbol,ENUM_TIMEFRAMES timeframe,CSupResConfig &cfg)
+  {
+   m_symbol=symbol;
+   m_timeframe=timeframe;
+   m_period=cfg.period;
+   m_draw_sup=cfg.draw_sup;
+   m_draw_res=cfg.draw_res;
+   m_sup_color=cfg.sup_color;
+   m_res_color=cfg.res_color;
+   m_sup_style=cfg.sup_style;
+   m_res_style=cfg.res_style;
+   m_sup_width=cfg.sup_width;
+   m_res_width=cfg.res_width;
+   m_extend_right=cfg.extend_right;
+   m_show_labels=cfg.show_labels;
+   m_alert_tf=cfg.alert_tf;
+
+   m_obj_sup="SR_SUP_"+IntegerToString(GetTickCount());
+   m_obj_res="SR_RES_"+IntegerToString(GetTickCount());
+
+   return Update();
+  }
+
+//+------------------------------------------------------------------+
+//| Default init                                                      |
+//+------------------------------------------------------------------+
+bool CSupRes::Init(string symbol,ENUM_TIMEFRAMES timeframe,int period)
+  {
+   CSupResConfig tmp;
+   tmp.period=period;
+   return Init(symbol,timeframe,tmp);
+  }
+
+//+------------------------------------------------------------------+
+//| Support value                                                     |
+//+------------------------------------------------------------------+
+double CSupRes::GetSupportValue(int shift)
+  {
+   if(shift==0)
+      return m_sup_val;
+   datetime t=iTime(m_symbol,m_alert_tf,shift);
+   if(t==0) return 0.0;
+   double val=ObjectGetValueByTime(0,m_obj_sup,t);
+   return val;
+  }
+
+//+------------------------------------------------------------------+
+//| Resistance value                                                  |
+//+------------------------------------------------------------------+
+double CSupRes::GetResistanceValue(int shift)
+  {
+   if(shift==0)
+      return m_res_val;
+   datetime t=iTime(m_symbol,m_alert_tf,shift);
+   if(t==0) return 0.0;
+   double val=ObjectGetValueByTime(0,m_obj_res,t);
+   return val;
+  }
+
+//+------------------------------------------------------------------+
+//| GetValue (support)                                                |
+//+------------------------------------------------------------------+
+double CSupRes::GetValue(int shift)
+  {
+   return GetSupportValue(shift);
+  }
+
+//+------------------------------------------------------------------+
+//| CopyValues (support)                                              |
+//+------------------------------------------------------------------+
+bool CSupRes::CopyValues(int shift,int count,double &buffer[])
+  {
+   ArrayResize(buffer,count);
+   for(int i=0;i<count;i++)
+      buffer[i]=GetValue(shift+i);
+   return true;
+  }
+
+//+------------------------------------------------------------------+
+//| Ready flag                                                        |
+//+------------------------------------------------------------------+
+bool CSupRes::IsReady()
+  {
+   return m_ready;
+  }
+
+//+------------------------------------------------------------------+
+//| Update support/resistance values                                  |
+//+------------------------------------------------------------------+
+bool CSupRes::Update()
+  {
+   int bars=m_period>0?m_period:50;
+   double highs[],lows[];
+   ArraySetAsSeries(highs,true);
+   ArraySetAsSeries(lows,true);
+   if(CopyHigh(m_symbol,m_timeframe,0,bars,highs)<=0)
+      return false;
+   if(CopyLow(m_symbol,m_timeframe,0,bars,lows)<=0)
+      return false;
+
+   int hi_idx=ArrayMaximum(highs);
+   int lo_idx=ArrayMinimum(lows);
+   m_res_val=highs[hi_idx];
+   m_sup_val=lows[lo_idx];
+   datetime hi_time=iTime(m_symbol,m_timeframe,hi_idx);
+   datetime lo_time=iTime(m_symbol,m_timeframe,lo_idx);
+
+   if(m_draw_res)
+      DrawLine(m_obj_res,m_res_val,m_res_color,m_res_style,m_res_width);
+   if(m_draw_sup)
+      DrawLine(m_obj_sup,m_sup_val,m_sup_color,m_sup_style,m_sup_width);
+
+   double close[];
+   ArraySetAsSeries(close,true);
+   if(CopyClose(m_symbol,m_alert_tf,0,2,close)>0)
+     {
+      m_breakup=(close[1]>m_res_val);
+      m_breakdown=(close[1]<m_sup_val);
+     }
+   else
+     {
+      m_breakup=false;
+      m_breakdown=false;
+     }
+
+   m_ready=true;
+   return true;
+  }
+
+bool CSupRes::IsBreakdown(){ return m_breakdown; }
+bool CSupRes::IsBreakup(){ return m_breakup; }
+
+#endif // __SUP_RES_MQH__

--- a/TF_CTX/priceaction/sup_res/sup_res_defs.mqh
+++ b/TF_CTX/priceaction/sup_res/sup_res_defs.mqh
@@ -1,0 +1,11 @@
+#ifndef __SUP_RES_DEFS_MQH__
+#define __SUP_RES_DEFS_MQH__
+
+// Types for support/resistance lines
+enum ENUM_SUPRES_LINE
+  {
+   SUP_LINE = 0,
+   RES_LINE = 1
+  };
+
+#endif // __SUP_RES_DEFS_MQH__

--- a/guide_implementacao_indicadores.md
+++ b/guide_implementacao_indicadores.md
@@ -1,0 +1,60 @@
+# Guia para Adicionar Novos Indicadores ou PriceActions
+
+Este documento resume os passos para criar e registrar novos componentes no EA **PA_WIN**.
+
+## 1. Criar a Classe
+
+1. **Definir cabeçalho `.mqh`** dentro da pasta apropriada (`TF_CTX/indicators` ou `TF_CTX/priceaction`).
+2. **Herdar** da classe base (`CIndicatorBase` ou `CPriceActionBase`).
+3. Implementar os métodos principais:
+   - `Init()` – configura parâmetros e aloca recursos.
+   - `GetValue()` / `CopyValues()` – retornam valores calculados.
+   - `IsReady()` – indica se o objeto está pronto.
+   - `Update()` – recalcula valores ou redesenha objetos quando necessário.
+4. (Opcional) Criar arquivo `*_defs.mqh` com enums ou constantes auxiliares.
+
+## 2. Configuração
+
+1. Adicione uma estrutura no arquivo `TF_CTX/config_types.mqh` derivada de `CIndicatorConfig` ou `CPriceActionConfig` para armazenar os parâmetros configuráveis.
+2. Defina valores padrão no construtor dessa estrutura.
+
+## 3. Fábricas
+
+1. Registre o novo tipo no `IndicatorFactory` ou `PriceActionFactory`.
+   - Inclua o cabeçalho do componente.
+   - Adicione a função estática de criação e chame `Register()` dentro de `RegisterDefaults()`.
+
+Exemplo:
+```cpp
+Register("SUPRES", CreateSupRes);
+```
+
+## 4. ConfigManager
+
+1. No `config_manager.mqh`, extenda o parser JSON para reconhecer o novo tipo.
+2. Para cada entrada encontrada, aloque a configuração específica e preencha os campos com os valores lidos do JSON.
+
+## 5. Uso no `config.json`
+
+Inclua um bloco semelhante ao abaixo no timeframe desejado:
+```json
+{
+   "name": "sr_simple",
+   "type": "SUPRES",
+   "period": 50,
+   "draw_sup": true,
+   "draw_res": true,
+   "sup_color": "Blue",
+   "res_color": "Red",
+   "sup_style": "SOLID",
+   "res_style": "SOLID",
+   "sup_width": 1,
+   "res_width": 1,
+   "extend_right": true,
+   "show_labels": false,
+   "alert_tf": "H1",
+   "enabled": true
+}
+```
+
+Após salvar o JSON e recarregar a configuração (função `ReloadConfig()`), o novo componente será criado automaticamente.


### PR DESCRIPTION
## Summary
- implement Support/Resistance price action
- parse SUPRES in ConfigManager
- register SUPRES in PriceActionFactory
- add configuration structure for SUPRES
- provide implementation guide for adding indicators/priceactions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863ebf0bbd083208fef10f4c107d9bd