### PR TITLE
Implement support/resistance zones

### DIFF
--- a/TF_CTX/config_manager.mqh
+++ b/TF_CTX/config_manager.mqh
@@ -800,6 +800,7 @@ STimeframeConfig CConfigManager::ParseTimeframeConfig(CJAVal *tf_config, ENUM_TI
             p.touch_lookback=(int)pa["touch_lookback"].ToInt();
             p.touch_tolerance=pa["touch_tolerance"].ToDbl();
             p.zone_range=pa["zone_range"].ToDbl();
+            p.max_zones_to_draw=(int)pa["max_zones_to_draw"].ToInt();
             p.min_touches=(int)pa["min_touches"].ToInt();
             p.validation=(ENUM_SUPRES_VALIDATION)pa["validation"].ToInt();
             p.alert_tf=StringToTimeframe(pa["alert_tf"].ToStr());

--- a/TF_CTX/config_manager.mqh
+++ b/TF_CTX/config_manager.mqh
@@ -799,6 +799,7 @@ STimeframeConfig CConfigManager::ParseTimeframeConfig(CJAVal *tf_config, ENUM_TI
             p.show_labels=pa["show_labels"].ToBool();
             p.touch_lookback=(int)pa["touch_lookback"].ToInt();
             p.touch_tolerance=pa["touch_tolerance"].ToDbl();
+            p.zone_range=pa["zone_range"].ToDbl();
             p.min_touches=(int)pa["min_touches"].ToInt();
             p.validation=(ENUM_SUPRES_VALIDATION)pa["validation"].ToInt();
             p.alert_tf=StringToTimeframe(pa["alert_tf"].ToStr());

--- a/TF_CTX/config_types.mqh
+++ b/TF_CTX/config_types.mqh
@@ -182,8 +182,9 @@ public:
    bool            show_labels;
    ENUM_TIMEFRAMES alert_tf;
    int             touch_lookback;
-   double          touch_tolerance;
-   int             min_touches;
+  double          touch_tolerance;
+  double          zone_range;
+  int             min_touches;
    ENUM_SUPRES_VALIDATION validation;
    CSupResConfig()
      {
@@ -194,6 +195,7 @@ public:
       alert_tf=PERIOD_H1;
       touch_lookback=20;
       touch_tolerance=0.0;
+      zone_range=10.0;
       min_touches=2;
       validation=SUPRES_VALIDATE_TOUCHES;
      }

--- a/TF_CTX/config_types.mqh
+++ b/TF_CTX/config_types.mqh
@@ -184,6 +184,7 @@ public:
    int             touch_lookback;
   double          touch_tolerance;
   double          zone_range;
+  int             max_zones_to_draw;
   int             min_touches;
    ENUM_SUPRES_VALIDATION validation;
    CSupResConfig()
@@ -196,6 +197,7 @@ public:
       touch_lookback=20;
       touch_tolerance=0.0;
       zone_range=10.0;
+      max_zones_to_draw=3;
       min_touches=2;
       validation=SUPRES_VALIDATE_TOUCHES;
      }

--- a/guide_implementacao_indicadores.md
+++ b/guide_implementacao_indicadores.md
@@ -57,6 +57,7 @@ todos os campos disponíveis para o **SUPRES**:
    "touch_lookback": 20,
    "touch_tolerance": 5.0,
    "zone_range": 10.0,
+   "max_zones_to_draw": 3,
    "min_touches": 2,
    "validation": 2,
    "enabled": true

--- a/guide_implementacao_indicadores.md
+++ b/guide_implementacao_indicadores.md
@@ -56,6 +56,7 @@ todos os campos disponíveis para o **SUPRES**:
    "alert_tf": "H1",
    "touch_lookback": 20,
    "touch_tolerance": 5.0,
+   "zone_range": 10.0,
    "min_touches": 2,
    "validation": 2,
    "enabled": true


### PR DESCRIPTION
## Summary
- enhance Support/Resistance indicator with zone detection
- store and draw S/R zones as rectangles
- add configurable `zone_range` option
- parse new config field
- document new parameter

## Testing
- `git diff --cached --stat`


------
https://chatgpt.com/codex/tasks/task_e_6865a7d6db788320b9775adeaa95f3d1