### PR TITLE
Handle limited bar data in Update methods

### DIFF
--- a/TF_CTX/bars_helper.mqh
+++ b/TF_CTX/bars_helper.mqh
@@ -1,0 +1,30 @@
+#ifndef __BARS_HELPER_MQH__
+#define __BARS_HELPER_MQH__
+
+//+------------------------------------------------------------------+
+//| Clamp requested bars to available bars on chart                   |
+//+------------------------------------------------------------------+
+inline int ClampBars(string symbol, ENUM_TIMEFRAMES timeframe, int requested)
+  {
+   int available = Bars(symbol, timeframe);
+   if(available <= 0)
+      return 0;
+   if(requested <= 0)
+      return available;
+   return MathMin(requested, available);
+  }
+
+//+------------------------------------------------------------------+
+//| Clamp requested bars to available bars for indicator handle       |
+//+------------------------------------------------------------------+
+inline int ClampBars(int handle, int requested)
+  {
+   int available = BarsCalculated(handle);
+   if(available <= 0)
+      return 0;
+   if(requested <= 0)
+      return available;
+   return MathMin(requested, available);
+  }
+
+#endif // __BARS_HELPER_MQH__

--- a/TF_CTX/indicators/bollinger/bollinger.mqh
+++ b/TF_CTX/indicators/bollinger/bollinger.mqh
@@ -8,6 +8,7 @@
 #include "../indicator_base.mqh"
 #include "../../config_types.mqh"
 #include "bollinger_defs.mqh"
+#include "../../bars_helper.mqh"
 
 class CBollinger : public CIndicatorBase
   {
@@ -142,7 +143,8 @@ double CBollinger::GetBufferValue(int buffer_index,int shift)
       return 0.0;
    double buf[];
    ArraySetAsSeries(buf,true);
-   if(CopyBuffer(m_handle,buffer_index,shift,1,buf)<=0)
+   int bars=ClampBars(m_handle,shift+1)-shift;
+   if(bars<=0 || CopyBuffer(m_handle,buffer_index,shift,bars,buf)<=0)
       return 0.0;
    return buf[0];
   }
@@ -178,9 +180,12 @@ bool CBollinger::CopyValues(int shift,int count,double &buffer[])
   {
    if(m_handle==INVALID_HANDLE)
       return false;
-   ArrayResize(buffer,count);
+   int bars=ClampBars(m_handle,shift+count)-shift;
+   if(bars<=0)
+      return false;
+   ArrayResize(buffer,bars);
    ArraySetAsSeries(buffer,true);
-   return CopyBuffer(m_handle,2,shift,count,buffer)>0;
+   return CopyBuffer(m_handle,2,shift,bars,buffer)>0;
   }
 
 //+------------------------------------------------------------------+
@@ -190,9 +195,12 @@ bool CBollinger::CopyUpper(int shift,int count,double &buffer[])
   {
    if(m_handle==INVALID_HANDLE)
       return false;
-   ArrayResize(buffer,count);
+   int bars=ClampBars(m_handle,shift+count)-shift;
+   if(bars<=0)
+      return false;
+   ArrayResize(buffer,bars);
    ArraySetAsSeries(buffer,true);
-   return CopyBuffer(m_handle,0,shift,count,buffer)>0;
+   return CopyBuffer(m_handle,0,shift,bars,buffer)>0;
   }
 
 //+------------------------------------------------------------------+
@@ -202,9 +210,12 @@ bool CBollinger::CopyLower(int shift,int count,double &buffer[])
   {
    if(m_handle==INVALID_HANDLE)
       return false;
-   ArrayResize(buffer,count);
+   int bars=ClampBars(m_handle,shift+count)-shift;
+   if(bars<=0)
+      return false;
+   ArrayResize(buffer,bars);
    ArraySetAsSeries(buffer,true);
-   return CopyBuffer(m_handle,1,shift,count,buffer)>0;
+   return CopyBuffer(m_handle,1,shift,bars,buffer)>0;
   }
 
 //+------------------------------------------------------------------+
@@ -212,7 +223,7 @@ bool CBollinger::CopyLower(int shift,int count,double &buffer[])
 //+------------------------------------------------------------------+
 bool CBollinger::IsReady()
   {
-   return (BarsCalculated(m_handle)>0);
+   return (ClampBars(m_handle,1)>0);
   }
 
 #endif // __BOLLINGER_MQH__

--- a/TF_CTX/indicators/fibonacci/fibonacci.mqh
+++ b/TF_CTX/indicators/fibonacci/fibonacci.mqh
@@ -8,6 +8,7 @@
 #include "../indicator_base.mqh"
 #include "../../config_types.mqh"
 #include "fibonacci_defs.mqh"
+#include "../../bars_helper.mqh"
 
 class CFibonacci : public CIndicatorBase
   {
@@ -268,14 +269,18 @@ bool CFibonacci::Update()
       double highs[];
       double lows[];
 
+      int bars=ClampBars(m_symbol,m_timeframe,m_bars);
+      if(bars<=0)
+         return(false);
+
       // Tratar arrays como séries antes de copiar valores
       ArraySetAsSeries(highs,true);
       ArraySetAsSeries(lows,true);
 
       // Copia os dados High/Low
-      if(CopyHigh(m_symbol,m_timeframe,0,m_bars,highs)<=0)
+      if(CopyHigh(m_symbol,m_timeframe,0,bars,highs)<=0)
          return(false);
-      if(CopyLow(m_symbol,m_timeframe,0,m_bars,lows)<=0)
+      if(CopyLow(m_symbol,m_timeframe,0,bars,lows)<=0)
          return(false);
 
       // Encontra índices de máximo e mínimo

--- a/TF_CTX/indicators/ma/moving_averages.mqh
+++ b/TF_CTX/indicators/ma/moving_averages.mqh
@@ -9,6 +9,7 @@
 #include "../indicator_base.mqh"
 #include "../../config_types.mqh"
 #include "ma_defs.mqh"
+#include "../../bars_helper.mqh"
 
 //+------------------------------------------------------------------+
 //| Classe para cálculo de médias móveis                            |
@@ -134,13 +135,14 @@ double CMovingAverages::GetIndicatorValue(int handle, int shift = 0)
     
     double buffer[];
     ArraySetAsSeries(buffer, true);
-    
-    if(CopyBuffer(handle, 0, shift, 1, buffer) <= 0)
+
+    int bars=ClampBars(handle,shift+1)-shift;
+    if(bars<=0 || CopyBuffer(handle, 0, shift, bars, buffer) <= 0)
     {
         Print("ERRO: Falha ao copiar dados do indicador");
         return 0.0;
     }
-    
+
     return buffer[0];
 }
 
@@ -163,10 +165,16 @@ bool CMovingAverages::CopyValues(int shift, int count, double &buffer[])
         return false;
     }
 
-    ArrayResize(buffer, count);
+    int bars=ClampBars(m_handle,shift+count)-shift;
+    if(bars<=0)
+    {
+        Print("ERRO: Falha ao copiar dados do indicador");
+        return false;
+    }
+    ArrayResize(buffer, bars);
     ArraySetAsSeries(buffer, true);
 
-    if(CopyBuffer(m_handle, 0, shift, count, buffer) <= 0)
+    if(CopyBuffer(m_handle, 0, shift, bars, buffer) <= 0)
     {
         Print("ERRO: Falha ao copiar dados do indicador");
         return false;
@@ -180,5 +188,5 @@ bool CMovingAverages::CopyValues(int shift, int count, double &buffer[])
 //+------------------------------------------------------------------+
 bool CMovingAverages::IsReady()
 {
-    return (BarsCalculated(m_handle) > 0);
+    return (ClampBars(m_handle,1) > 0);
 }

--- a/TF_CTX/indicators/stochastic/stochastic.mqh
+++ b/TF_CTX/indicators/stochastic/stochastic.mqh
@@ -9,6 +9,7 @@
 #include "../indicator_base.mqh"
 #include "../../config_types.mqh"
 #include "stochastic_defs.mqh"
+#include "../../bars_helper.mqh"
 
 //+------------------------------------------------------------------+
 //| Classe para cálculo do Estocástico                               |
@@ -162,7 +163,8 @@ double CStochastic::GetBufferValue(int buffer_index, int shift)
    double buffer[];
    ArraySetAsSeries(buffer, true);
 
-   if(CopyBuffer(m_handle, buffer_index, shift, 1, buffer) <= 0)
+   int bars=ClampBars(m_handle,shift+1)-shift;
+   if(bars<=0 || CopyBuffer(m_handle, buffer_index, shift, bars, buffer) <= 0)
      {
       Print("ERRO: Falha ao copiar dados do Stochastic");
       return 0.0;
@@ -197,9 +199,15 @@ bool CStochastic::CopyValues(int shift, int count, double &buffer[])
       Print("ERRO: Handle do Stochastic inválido");
       return false;
      }
-   ArrayResize(buffer, count);
+   int bars=ClampBars(m_handle,shift+count)-shift;
+   if(bars<=0)
+     {
+      Print("ERRO: Falha ao copiar dados do Stochastic");
+      return false;
+     }
+   ArrayResize(buffer, bars);
    ArraySetAsSeries(buffer, true);
-   if(CopyBuffer(m_handle, 0, shift, count, buffer) <= 0)
+   if(CopyBuffer(m_handle, 0, shift, bars, buffer) <= 0)
      {
       Print("ERRO: Falha ao copiar dados do Stochastic");
       return false;
@@ -217,9 +225,15 @@ bool CStochastic::CopySignalValues(int shift, int count, double &buffer[])
       Print("ERRO: Handle do Stochastic inválido");
       return false;
      }
-   ArrayResize(buffer, count);
+   int bars=ClampBars(m_handle,shift+count)-shift;
+   if(bars<=0)
+     {
+      Print("ERRO: Falha ao copiar dados do Stochastic");
+      return false;
+     }
+   ArrayResize(buffer, bars);
    ArraySetAsSeries(buffer, true);
-   if(CopyBuffer(m_handle, 1, shift, count, buffer) <= 0)
+   if(CopyBuffer(m_handle, 1, shift, bars, buffer) <= 0)
      {
       Print("ERRO: Falha ao copiar dados do Stochastic");
       return false;
@@ -232,7 +246,7 @@ bool CStochastic::CopySignalValues(int shift, int count, double &buffer[])
 //+------------------------------------------------------------------+
 bool CStochastic::IsReady()
   {
-   return (BarsCalculated(m_handle) > 0);
+   return (ClampBars(m_handle,1) > 0);
   }
 
 //+------------------------------------------------------------------+

--- a/TF_CTX/indicators/volume/volume.mqh
+++ b/TF_CTX/indicators/volume/volume.mqh
@@ -9,6 +9,7 @@
 #include "../indicator_base.mqh"
 #include "../../config_types.mqh"
 #include "volume_defs.mqh"
+#include "../../bars_helper.mqh"
 
 //+------------------------------------------------------------------+
 //| Classe para acesso ao volume                                     |
@@ -96,6 +97,6 @@ bool CVolume::CopyValues(int shift, int count, double &buffer[])
 //+------------------------------------------------------------------+
 bool CVolume::IsReady()
   {
-   return (Bars(m_symbol,m_timeframe) > m_base_shift);
+  return (ClampBars(m_symbol,m_timeframe,m_base_shift+1) > m_base_shift);
   }
 

--- a/TF_CTX/indicators/vwap/vwap.mqh
+++ b/TF_CTX/indicators/vwap/vwap.mqh
@@ -8,6 +8,7 @@
 #include "../indicator_base.mqh"
 #include "vwap_defs.mqh"
 #include "../../config_types.mqh"
+#include "../../bars_helper.mqh"
 
 class CVWAP : public CIndicatorBase
   {
@@ -197,7 +198,7 @@ bool CVWAP::CopyValues(int shift,int count,double &buffer[])
 //+------------------------------------------------------------------+
 bool CVWAP::IsReady()
   {
-  return (Bars(m_symbol,m_timeframe) > 0);
+  return (ClampBars(m_symbol,m_timeframe,1) > 0);
   }
 
 //+------------------------------------------------------------------+
@@ -291,7 +292,7 @@ double CVWAP::TypicalPrice(int index)
 //+------------------------------------------------------------------+
 void CVWAP::ComputeAll()
   {
-   int bars=Bars(m_symbol,m_timeframe);
+   int bars=ClampBars(m_symbol,m_timeframe,0);
    if(bars<=0)
       return;
    ArrayResize(m_vwap_buffer,bars);
@@ -386,7 +387,7 @@ bool CVWAP::IsNewSession(int bar_index)
 //+------------------------------------------------------------------+
 void CVWAP::UpdateCurrentBar()
   {
-  int bars=Bars(m_symbol,m_timeframe);
+  int bars=ClampBars(m_symbol,m_timeframe,0);
   if(bars<=0)
       return;
 
@@ -445,7 +446,7 @@ bool CVWAP::Update()
    if(!IsReady())
       return(false);
 
-   int bars=Bars(m_symbol,m_timeframe);
+   int bars=ClampBars(m_symbol,m_timeframe,0);
    int current_size=ArraySize(m_vwap_buffer);
 
   if(bars<=current_size && current_size>0)

--- a/TF_CTX/priceaction/sup_res/sup_res.mqh
+++ b/TF_CTX/priceaction/sup_res/sup_res.mqh
@@ -8,6 +8,7 @@
 #include "../priceaction_base.mqh"
 #include "sup_res_defs.mqh"
 #include "../../config_types.mqh"
+#include "../bars_helper.mqh"
 
 // Structure representing a support/resistance zone
 struct SRZone
@@ -560,7 +561,10 @@ bool CSupRes::IsReady()
 //+------------------------------------------------------------------+
 bool CSupRes::Update()
   {
-  int bars=m_period>0?m_period:50;
+  int bars_required=m_period>0?m_period:50;
+  int bars=ClampBars(m_symbol,m_timeframe,bars_required);
+  if(bars<=0)
+     return false;
   double highs[],lows[],opens[],closes[];
    ArraySetAsSeries(highs,true);
    ArraySetAsSeries(lows,true);
@@ -696,7 +700,8 @@ bool CSupRes::Update()
 
    double close[];
    ArraySetAsSeries(close,true);
-   if(CopyClose(m_symbol,m_alert_tf,0,2,close)>0)
+   int alert_bars=ClampBars(m_symbol,m_alert_tf,2);
+   if(alert_bars>=2 && CopyClose(m_symbol,m_alert_tf,0,alert_bars,close)>0)
      {
       m_breakup=false;
       double nearest_res=DBL_MAX;

--- a/TF_CTX/priceaction/trendline/trendline.mqh
+++ b/TF_CTX/priceaction/trendline/trendline.mqh
@@ -8,6 +8,7 @@
 #include "../priceaction_base.mqh"
 #include "trendline_defs.mqh"
 #include "../../config_types.mqh"
+#include "../bars_helper.mqh"
 
 class CTrendLine : public CPriceActionBase
   {
@@ -228,7 +229,10 @@ bool CTrendLine::Update()
    if(m_fractal_handle==INVALID_HANDLE)
       return false;
 
-   int bars=m_period>0?m_period:50;
+   int bars_required=m_period>0?m_period:50;
+   int bars=ClampBars(m_symbol,m_fractal_tf,bars_required);
+   if(bars<=0)
+      return false;
    double up[],down[];
    ArraySetAsSeries(up,true);
    ArraySetAsSeries(down,true);
@@ -280,8 +284,10 @@ ArraySetAsSeries(close, true);
 ArraySetAsSeries(ct, true);
 
 
-  if(CopyClose(m_symbol,m_alert_tf,0,2,close)>0 &&
-     CopyTime(m_symbol,m_alert_tf,0,2,ct)>0)
+  int alert_bars=ClampBars(m_symbol,m_alert_tf,2);
+  if(alert_bars>=2 &&
+     CopyClose(m_symbol,m_alert_tf,0,alert_bars,close)>0 &&
+     CopyTime(m_symbol,m_alert_tf,0,alert_bars,ct)>0)
     {
      double sup=ObjectGetValueByTime(0,m_obj_lta,ct[1]);
      double res=ObjectGetValueByTime(0,m_obj_ltb,ct[1]);


### PR DESCRIPTION
## Summary
- handle situations when not enough historical bars are loaded
- clamp requested bars for support/resistance, trend line, fibonacci, and other indicators using new helper

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867168fc234832097b1b1a97a97672b