### PR TITLE
Refactor VWAP indicator to use buffer

### DIFF
--- a/TF_CTX/config_manager.mqh
+++ b/TF_CTX/config_manager.mqh
@@ -674,10 +674,6 @@ STimeframeConfig CConfigManager::ParseTimeframeConfig(CJAVal *tf_config, ENUM_TI
               p.price_type=StringToVWAPPriceType(ind["price_type"].ToStr());
               string start_str=ind["start_time"].ToStr();
               if(StringLen(start_str)>0) p.start_time=StringToTime(start_str);
-              col=ind["Color"].ToStr();
-              p.line_color=StringToColor(col);
-              p.line_style=StringToLineStyle(ind["Style"].ToStr());
-              p.line_width=(int)ind["Width"].ToInt();
               icfg=p;
              }
            else if(type=="BOLL")

--- a/TF_CTX/config_types.mqh
+++ b/TF_CTX/config_types.mqh
@@ -64,14 +64,11 @@ public:
    ENUM_TIMEFRAMES     session_tf;
    ENUM_VWAP_PRICE_TYPE price_type;
    datetime            start_time;
-   color               line_color;
-   ENUM_LINE_STYLE     line_style;
-   int                 line_width;
    CVWAPConfig()
      {
       period=0; method=MODE_SMA; calc_mode=VWAP_CALC_BAR;
       session_tf=PERIOD_D1; price_type=VWAP_PRICE_FINANCIAL_AVERAGE;
-      start_time=0; line_color=clrAqua; line_style=STYLE_SOLID; line_width=1;
+      start_time=0;
      }
   };
 

--- a/TF_CTX/factories/indicator_factory.mqh
+++ b/TF_CTX/factories/indicator_factory.mqh
@@ -132,7 +132,7 @@ CIndicatorBase* CIndicatorFactory::CreateVWAP(string symbol, ENUM_TIMEFRAMES tf,
    if(c==NULL)
       return NULL;
    CVWAP *ind = new CVWAP();
-   if(ind!=NULL && ind.Init(symbol, tf, c.period, c.method, c.calc_mode, c.session_tf, c.price_type, c.start_time, c.line_color, c.line_style, c.line_width))
+   if(ind!=NULL && ind.Init(symbol, tf, c.period, c.method, c.calc_mode, c.session_tf, c.price_type, c.start_time))
       return ind;
    delete ind;
    return NULL;

--- a/TF_CTX/indicators/vwap/vwap.mqh
+++ b/TF_CTX/indicators/vwap/vwap.mqh
@@ -16,11 +16,6 @@ private:
    ENUM_TIMEFRAMES m_timeframe;
    int             m_period;
    ENUM_MA_METHOD  m_method;
-   color           m_color;
-   ENUM_LINE_STYLE m_style;
-   int             m_width;
-   string          m_obj_prefix;
-   string          m_line_names[];
    ENUM_VWAP_CALC_MODE m_calc_mode;
    ENUM_VWAP_PRICE_TYPE m_price_type;
    ENUM_TIMEFRAMES     m_session_tf;
@@ -31,9 +26,6 @@ private:
    bool            IsNewSession(int bar_index);
    void            UpdateCurrentBar();
 
-   void            DeleteObjects();
-
-   void            DrawLines(bool full_redraw);
 
    double          TypicalPrice(int index);
    void            ComputeAll();
@@ -48,11 +40,7 @@ public:
                         ENUM_VWAP_CALC_MODE calc_mode,
                         ENUM_TIMEFRAMES session_tf,
                         ENUM_VWAP_PRICE_TYPE price_type,
-                        datetime start_time,
-                        color line_color,
-                        ENUM_LINE_STYLE line_style=STYLE_SOLID,
-                        int line_width=1,
-                        string obj_prefix="");
+                        datetime start_time);
   bool             Init(string symbol, ENUM_TIMEFRAMES timeframe,
                         CVWAPConfig &config);
   virtual bool     Init(string symbol, ENUM_TIMEFRAMES timeframe,
@@ -77,11 +65,6 @@ CVWAP::CVWAP()
    m_timeframe=PERIOD_CURRENT;
    m_period=1;
    m_method=MODE_SMA;
-   m_color=clrAqua;
-   m_style=STYLE_SOLID;
-   m_width=1;
-   m_obj_prefix="";
-   ArrayResize(m_line_names,0);
    m_calc_mode=VWAP_CALC_BAR;
    m_price_type=VWAP_PRICE_FINANCIAL_AVERAGE;
    m_session_tf=PERIOD_D1;
@@ -95,10 +78,8 @@ CVWAP::CVWAP()
 //+------------------------------------------------------------------+
 CVWAP::~CVWAP()
   {
-   DeleteObjects();
    ArrayResize(m_vwap_buffer,0);
    ArrayFree(m_vwap_buffer);
-   ArrayResize(m_line_names,0);
   }
 
 //+------------------------------------------------------------------+
@@ -109,11 +90,7 @@ bool CVWAP::Init(string symbol, ENUM_TIMEFRAMES timeframe,
                  ENUM_VWAP_CALC_MODE calc_mode,
                  ENUM_TIMEFRAMES session_tf,
                  ENUM_VWAP_PRICE_TYPE price_type,
-                 datetime start_time,
-                 color line_color,
-                 ENUM_LINE_STYLE line_style,
-                 int line_width,
-                 string obj_prefix)
+                 datetime start_time)
   {
    if(StringLen(symbol)==0)
       return false;
@@ -125,13 +102,8 @@ bool CVWAP::Init(string symbol, ENUM_TIMEFRAMES timeframe,
    m_price_type=price_type;
    m_session_tf=session_tf;
    m_start_time=start_time;
-   m_color=line_color;
-   m_style=line_style;
-   m_width=line_width;
-   m_obj_prefix=obj_prefix;
    m_last_calculated_time=0;
    ArrayResize(m_vwap_buffer,0);
-   ArrayResize(m_line_names,0);
    return true;
   }
 
@@ -143,8 +115,7 @@ bool CVWAP::Init(string symbol, ENUM_TIMEFRAMES timeframe,
   {
   return Init(symbol,timeframe,period,method,
               VWAP_CALC_BAR,PERIOD_D1,
-              VWAP_PRICE_FINANCIAL_AVERAGE,0,clrAqua,
-              STYLE_SOLID,1,"");
+              VWAP_PRICE_FINANCIAL_AVERAGE,0);
   }
 
 bool CVWAP::Init(string symbol, ENUM_TIMEFRAMES timeframe,
@@ -152,8 +123,7 @@ bool CVWAP::Init(string symbol, ENUM_TIMEFRAMES timeframe,
   {
    return Init(symbol, timeframe, config.period, config.method,
                config.calc_mode, config.session_tf, config.price_type,
-               config.start_time, config.line_color,
-               config.line_style, config.line_width, "");
+               config.start_time);
   }
 
 //+------------------------------------------------------------------+
@@ -198,69 +168,6 @@ bool CVWAP::CopyValues(int shift,int count,double &buffer[])
 bool CVWAP::IsReady()
   {
   return (Bars(m_symbol,m_timeframe) > 0);
-  }
-
-//+------------------------------------------------------------------+
-//| Delete previously drawn objects                                  |
-//+------------------------------------------------------------------+
-void CVWAP::DeleteObjects()
-  {
-   for(int i=0;i<ArraySize(m_line_names);i++)
-      if(ObjectFind(0,m_line_names[i])>=0)
-         ObjectDelete(0,m_line_names[i]);
-   ArrayResize(m_line_names,0);
-  }
-
-//+------------------------------------------------------------------+
-//| Draw VWAP lines on the chart                                      |
-//+------------------------------------------------------------------+
-void CVWAP::DrawLines(bool full_redraw)
-  {
-   int bars=ArraySize(m_vwap_buffer);
-   if(bars<2)
-     {
-      DeleteObjects();
-      return;
-     }
-
-   int needed=bars-1;
-   if(full_redraw)
-     {
-      DeleteObjects();
-      ArrayResize(m_line_names,needed);
-      for(int i=0;i<needed;i++)
-        {
-         string name=(StringLen(m_obj_prefix)>0?m_obj_prefix:"VWAP_")+IntegerToString(i);
-         if(ObjectCreate(0,name,OBJ_TREND,0,0,0,0,0))
-           {
-            ObjectSetInteger(0,name,OBJPROP_RAY_RIGHT,false);
-            ObjectSetInteger(0,name,OBJPROP_RAY_LEFT,false);
-           }
-         m_line_names[i]=name;
-        }
-     }
-   else if(ArraySize(m_line_names)!=needed)
-     {
-      DrawLines(true);
-      return;
-     }
-
-   for(int i=0;i<needed;i++)
-     {
-      double val1=m_vwap_buffer[i+1];
-      double val2=m_vwap_buffer[i];
-      datetime time1=iTime(m_symbol,m_timeframe,i+1);
-      datetime time2=iTime(m_symbol,m_timeframe,i);
-      string name=m_line_names[i];
-
-      ObjectSetInteger(0,name,OBJPROP_TIME,0,time1);
-      ObjectSetDouble(0,name,OBJPROP_PRICE,0,val1);
-      ObjectSetInteger(0,name,OBJPROP_TIME,1,time2);
-      ObjectSetDouble(0,name,OBJPROP_PRICE,1,val2);
-      ObjectSetInteger(0,name,OBJPROP_COLOR,m_color);
-      ObjectSetInteger(0,name,OBJPROP_STYLE,m_style);
-      ObjectSetInteger(0,name,OBJPROP_WIDTH,m_width);
-     }
   }
 
 //+------------------------------------------------------------------+
@@ -451,12 +358,10 @@ bool CVWAP::Update()
   if(bars<=current_size && current_size>0)
     {
     UpdateCurrentBar();
-    DrawLines(false);
      return(true);
     }
 
   ComputeAll();
-  DrawLines(true);
   return(true);
   }
 

--- a/config.json
+++ b/config.json
@@ -139,9 +139,6 @@
                "calc_mode": "PERIODIC",
                "session_tf": "D1",
                "price_type": "FINANCIAL_AVERAGE",
-               "Color": "Blue",
-               "Style": "SOLID",
-               "Width": 1,
                "enabled": true
             },
             {
@@ -210,9 +207,6 @@
                "calc_mode": "PERIODIC",
                "session_tf": "D1",
                "price_type": "FINANCIAL_AVERAGE",
-               "Color": "Blue",
-               "Style": "SOLID",
-               "Width": 1,
                "enabled": true
             },
             {

--- a/documentation.md
+++ b/documentation.md
@@ -671,7 +671,7 @@ Esta seção detalha as principais funções e classes encontradas no código do
     - `slowing` (`int`): Valor de `slowing` (apenas para Estocástico).
     - `shift` (`int`): Deslocamento base para indicadores que utilizam série de preços (ex: Volume).
     - `price_field` (`ENUM_STO_PRICE`): Campo de preço utilizado.
-    - `vwap_calc_mode`, `vwap_session_tf`, `vwap_price_type`, `vwap_start_time`, `vwap_color`: Parâmetros específicos do indicador VWAP.
+    - `vwap_calc_mode`, `vwap_session_tf`, `vwap_price_type`, `vwap_start_time`: Parâmetros específicos do indicador VWAP.
     - `enabled` (`bool`): Indica se o indicador está habilitado.
     - `level_1` a `level_6` (`double`): Valores dos níveis de retração de Fibonacci.
     - `levels_color`, `levels_style`, `levels_width`: Aparência das linhas de retração.
@@ -912,9 +912,6 @@ Os campos `LevelsColor`, `ExtensionsColor`, `ParallelColor`, `LabelsColor` e `Co
        "session_tf": "D1",
        "price_type": "HLC3",
        "start_time": "2025-01-01 09:00:00",
-       "Color": "Blue",
-       "Style": "SOLID",
-       "Width": 2,
        "enabled": true
     }
     ```
@@ -922,9 +919,6 @@ Os campos `LevelsColor`, `ExtensionsColor`, `ParallelColor`, `LabelsColor` e `Co
     - `session_tf`: timeframe utilizado para detectar o início das sessões (por exemplo, `D1` ou `W1`).
     - `price_type`: forma de cálculo do preço típico, como `OPEN`, `CLOSE`, `HL2`, `HLC3` ou `OHLC4`.
     - `start_time`: usado apenas no modo `FROM_DATE` para indicar a data/hora inicial.
-    - `Color`: define a cor da linha de VWAP.
-    - `Style`: estilo de linha (ex. `SOLID`, `DASH`).
-    - `Width`: espessura da linha em pixels.
 
 Exemplo de configuração para cálculo **PERIODIC**, sessão diária, com preço
     de **média financeira**:
@@ -937,7 +931,6 @@ Exemplo de configuração para cálculo **PERIODIC**, sessão diária, com preç
        "calc_mode": "PERIODIC",
        "session_tf": "D1",
        "price_type": "FINANCIAL_AVERAGE",
-       "Color": "Blue",
        "enabled": true
     }
     ```
@@ -1016,8 +1009,9 @@ Esta seção registra as principais alterações e versões dos componentes do E
 -   **Versao 3.00**: Reescrita completa com cálculo acumulado por sessão, modos de cálculo e suporte a diferentes tipos de preço.
 -   **Versao 4.00**: Corrige o cálculo por barras, inclui métodos de configuração e atualização incremental.
 -   **Versao 5.00**: Melhora a detecção de sessões e o cálculo da barra atual.
--   **Versao 6.00**: Permite definir a cor da linha VWAP via JSON.
--   **Versao 7.00**: Suporte a estilo e largura de linha configuráveis via JSON.
+ -   **Versao 6.00**: Permite definir a cor da linha VWAP via JSON.
+ -   **Versao 7.00**: Suporte a estilo e largura de linha configuráveis via JSON.
+ -   **Versao 8.00**: Adaptação completa para uso como indicador buffer, sem desenho automático de objetos.
 
 ### fibonacci.mqh
 


### PR DESCRIPTION
## Summary
- update VWAP indicator to store values only in buffers
- drop object drawing parameters from configuration
- adjust indicator factory and config manager accordingly
- remove VWAP color/style options from docs and config examples

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68682c6d30a88320a099cfe64ad31252