### PR TITLE
Extend support/resistance zones to the right

### DIFF
--- a/TF_CTX/priceaction/sup_res/sup_res.mqh
+++ b/TF_CTX/priceaction/sup_res/sup_res.mqh
@@ -205,6 +205,8 @@ void CSupRes::DrawZone(string name,double lower,double upper,color col)
   {
    datetime t1=iTime(m_symbol,m_timeframe,m_period-1);
    datetime t2=iTime(m_symbol,m_timeframe,0);
+   if(m_extend_right)
+      t2 += (datetime)(PeriodSeconds(m_timeframe)*m_period*10);
    if(ObjectFind(0,name)<0)
       ObjectCreate(0,name,OBJ_RECTANGLE,0,t1,lower,t2,upper);
    else

--- a/documentation.md
+++ b/documentation.md
@@ -962,6 +962,20 @@ Exemplo de configuração para cálculo **PERIODIC**, sessão diária, com preç
     - `deviation`: multiplicador de desvio padrão.
     - `applied_price`: preço base (ex.: `CLOSE`, `OPEN`, `HIGH`, `LOW`, `MEDIAN`, `TYPICAL`, `WEIGHTED`).
 
+6.  **Estendendo Zonas de Suporte/Resistência para a Direita:**
+    Defina `extend_right` como `true` no bloco `SUPRES` para que as áreas permaneçam visíveis após o último candle:
+
+    ```json
+    {
+       "name": "sr_exemplo",
+       "type": "SUPRES",
+       "period": 50,
+       "extend_right": true,
+       "enabled": true
+    }
+    ```
+    Ao habilitar essa opção, as zonas de suporte e resistência serão desenhadas além do candle mais recente.
+
 **Observação Importante:** Para que o EA leia o `config.json`, o arquivo deve ser salvo na pasta `MQL5/Files` ou `Common/Files` do seu terminal MetaTrader 5. O parâmetro de entrada `JsonConfigFile` no EA deve corresponder ao nome do arquivo (ex: `config.json`).
 
 


### PR DESCRIPTION
## Summary
- allow support/resistance zones to extend beyond the most recent candle
- document how to enable `extend_right`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6869b86163f88320a9fc8a75bc40594f