### PR TITLE
Integrate ebook comments for trend logic

### DIFF
--- a/PA_WIN.mq5
+++ b/PA_WIN.mq5
@@ -10,6 +10,7 @@
 #property version "2.00"
 
 #include "TF_CTX/config_manager.mqh"
+#include "TF_CTX/analysis/trend_identifier.mqh"
 
 // Gerenciador de configuração
 CConfigManager *g_config_manager;
@@ -164,6 +165,23 @@ void ExecuteOnNewBar()
       //    Print("LTA H1 atual: ", lta);
       // }
    }
+
+   // Avaliar tendência geral utilizando os principais timeframes
+   TF_CTX *ctx_m15 = g_config_manager.GetContext(configured_symbol, PERIOD_M15);
+   TF_CTX *ctx_h1  = g_config_manager.GetContext(configured_symbol, PERIOD_H1);
+   TF_CTX *ctx_h4  = g_config_manager.GetContext(configured_symbol, PERIOD_H4);
+
+   CTrendIdentifier trend;
+   trend.Init(configured_symbol, ctx_m15, ctx_h1, ctx_h4);
+   ENUM_TREND_STATE trend_state = trend.Detect();
+
+   string trend_text = "NEUTRAL";
+   if(trend_state==TREND_BULLISH)
+      trend_text = "BULLISH";
+   else if(trend_state==TREND_BEARISH)
+      trend_text = "BEARISH";
+
+   Print("Tendência atual: ", trend_text);
 }
 
 //+------------------------------------------------------------------+

--- a/TF_CTX/analysis/trend_identifier.mqh
+++ b/TF_CTX/analysis/trend_identifier.mqh
@@ -1,0 +1,117 @@
+#ifndef __TREND_IDENTIFIER_MQH__
+#define __TREND_IDENTIFIER_MQH__
+
+#include "../tf_ctx.mqh"
+
+// Este módulo condensa regras do eBook "Identificação de Tendência para WINM25"
+// Ele avalia EMAs, VWAP e Bandas de Bollinger em timeframes M15, H1 e H4 para
+// determinar se o mercado está em alta, baixa ou neutro. Cada bloco abaixo
+// segue as recomendações do capítulo 4 do eBook, onde múltiplos timeframes e
+// confluência de indicadores são usados para confirmar a direção predominante.
+
+// Estado da tendência
+enum ENUM_TREND_STATE
+  {
+   TREND_NEUTRAL = 0,
+   TREND_BULLISH = 1,
+   TREND_BEARISH = -1
+  };
+
+class CTrendIdentifier
+  {
+private:
+   TF_CTX *m_ctx_m15;
+   TF_CTX *m_ctx_h1;
+   TF_CTX *m_ctx_h4;
+   string  m_symbol;
+public:
+                     CTrendIdentifier() { m_ctx_m15=NULL; m_ctx_h1=NULL; m_ctx_h4=NULL; m_symbol=""; }
+   bool               Init(string symbol, TF_CTX *m15, TF_CTX *h1, TF_CTX *h4)
+                       {
+                        m_symbol=symbol;
+                        m_ctx_m15=m15;
+                        m_ctx_h1=h1;
+                        m_ctx_h4=h4;
+                        return true;
+                       }
+   ENUM_TREND_STATE   Detect();
+  };
+
+ENUM_TREND_STATE CTrendIdentifier::Detect()
+  {
+   int up=0, down=0;
+
+   //--- M15 indicadores principais
+   // Conforme o eBook, a tendência no M15 ganha força quando EMA9 supera EMA21
+   // e o preço se mantém acima delas. VWAP ascendente e Bandas de Bollinger
+   // abertas reforçam o cenário de alta; o contrário indica possível queda.
+   if(m_ctx_m15!=NULL)
+     {
+      double ema9_cur  = m_ctx_m15.GetIndicatorValue("ema9",0);
+      double ema21_cur = m_ctx_m15.GetIndicatorValue("ema21",0);
+      double ema9_prev = m_ctx_m15.GetIndicatorValue("ema9",1);
+      double ema21_prev = m_ctx_m15.GetIndicatorValue("ema21",1);
+      double price_m15 = iClose(m_symbol,PERIOD_M15,0);
+      if(ema9_cur>ema21_cur && price_m15>ema9_cur && ema9_cur>ema9_prev && ema21_cur>ema21_prev)
+         up++;
+      else if(ema9_cur<ema21_cur && price_m15<ema9_cur && ema9_cur<ema9_prev && ema21_cur<ema21_prev)
+         down++;
+
+      // VWAP diário: preço acima e VWAP inclinada para cima apontam confluência
+      // de compra. Se o preço estiver abaixo e a VWAP inclinar para baixo, soma
+      // pontos para a venda.
+      double vwap_cur = m_ctx_m15.GetIndicatorValue("vwap_diario_fin",0);
+      double vwap_prev = m_ctx_m15.GetIndicatorValue("vwap_diario_fin",1);
+      if(price_m15>vwap_cur && vwap_cur>vwap_prev)
+         up++;
+      else if(price_m15<vwap_cur && vwap_cur<vwap_prev)
+         down++;
+
+      // Bandas de Bollinger: quando a banda média (20 períodos) está inclinada
+      // para cima e o preço se move acima dela, a volatilidade tende a favorecer
+      // a continuação da alta. A inclinação descendente sugere venda.
+      double boll_mid = m_ctx_m15.GetIndicatorValue("boll20",0);
+      double boll_prev = m_ctx_m15.GetIndicatorValue("boll20",1);
+      if(price_m15>boll_mid && boll_mid>boll_prev)
+         up++;
+      else if(price_m15<boll_mid && boll_mid<boll_prev)
+         down++;
+     }
+
+   //--- H1 EMA50
+   // O eBook define a EMA50 como guia da tendência de médio prazo. Preço e
+   // média inclinados para cima reforçam compras; valores abaixo indicam venda.
+   if(m_ctx_h1!=NULL)
+     {
+      double ema50_cur = m_ctx_h1.GetIndicatorValue("ema50",0);
+      double ema50_prev = m_ctx_h1.GetIndicatorValue("ema50",1);
+      double price_h1 = iClose(m_symbol,PERIOD_H1,0);
+      if(price_h1>ema50_cur && ema50_cur>ema50_prev)
+         up++;
+      else if(price_h1<ema50_cur && ema50_cur<ema50_prev)
+         down++;
+     }
+
+   //--- H4 SMA200
+   // A SMA200 é a referência de longo prazo. De acordo com o eBook, tendência
+   // principal de alta ocorre quando o preço está acima dela e a média se
+   // inclina para cima; caso contrário há viés baixista.
+   if(m_ctx_h4!=NULL)
+     {
+      double sma200_cur = m_ctx_h4.GetIndicatorValue("sma200",0);
+      double sma200_prev = m_ctx_h4.GetIndicatorValue("sma200",1);
+      double price_h4 = iClose(m_symbol,PERIOD_H4,0);
+      if(price_h4>sma200_cur && sma200_cur>sma200_prev)
+         up++;
+      else if(price_h4<sma200_cur && sma200_cur<sma200_prev)
+         down++;
+     }
+
+   // Resultado final: se as pontuações de alta superam as de baixa, o mercado
+   // é considerado em tendência de alta e vice-versa. Empate indica neutralidade.
+   if(up>down) return TREND_BULLISH;
+   if(down>up) return TREND_BEARISH;
+   return TREND_NEUTRAL;
+  }
+
+#endif // __TREND_IDENTIFIER_MQH__

--- a/documentation.md
+++ b/documentation.md
@@ -41,10 +41,10 @@ O Expert Advisor PA_WIN opera com uma arquitetura modular, centrada em um `CConf
 
 3.  **Lógica em Novo Candle (`ExecuteOnNewBar`):**
     *   Esta função é o coração da lógica de execução do EA em cada novo candle.
-    *   Atualmente, ela obtém o contexto `TF_CTX` para o símbolo fixo "WIN$N" no timeframe D1.
-     *   Chama o método `Update()` no contexto D1, o qual percorre todos os indicadores e executa `Update()` em cada um (herdado de `CIndicatorBase` ou sobrescrito), garantindo que fiquem sincronizados.
-    *   Exibe os valores das EMAs 9 e 21 para o candle atual (shift 1) e o anterior (shift 0) para fins de depuração.
-    *   A lógica de negociação real seria implementada aqui, utilizando os dados fornecidos pelos objetos `TF_CTX`.
+    *   Todos os contextos configurados no JSON para o símbolo fixo "WIN$N" são obtidos dinamicamente.
+    *   Cada `TF_CTX` é atualizado individualmente, garantindo que os indicadores e price actions estejam sincronizados.
+    *   Após a atualização, o módulo `CTrendIdentifier` avalia os contextos dos timeframes M15, H1 e H4 para determinar se o mercado está em tendência de alta, baixa ou neutra.
+    *   O resultado da tendência é impresso para fins de depuração e pode ser utilizado pela estratégia de negociação.
 
 4.  **Desinicialização (`OnDeinit`):**
     *   Quando o EA é removido do gráfico ou o terminal é fechado, o destrutor do `CConfigManager` é chamado, liberando todos os recursos alocados (instâncias de `TF_CTX` e `CMovingAverages`).
@@ -96,6 +96,7 @@ Esta seção detalha cada arquivo que compõe o Expert Advisor, explicando seu p
  - **`vwap.mqh`**: Implementa a classe `CVWAP`, derivada de `CIndicatorBase`, agora baseada no indicador `vwap_indicator.mq5` para cálculo do VWAP, delegando a exibição exclusivamente a esse indicador.
 - **`vwap_indicator.mq5`**: Indicador personalizado chamado via `iCustom` que desenha a linha de VWAP automaticamente.
 - **`fibonacci.mqh`**: Implementa o indicador `CFibonacci`, capaz de desenhar níveis de retração e extensões de Fibonacci com total customização via JSON.
+- **`trend_identifier.mqh`**: Módulo de análise que combina informações de diferentes timeframes para apontar se o mercado está em tendência de alta, baixa ou neutra. Agora contém comentários detalhando a lógica retirada do eBook *Identificação de Tendência para WINM25*.
 - **Arquivos `*_defs.mqh`**: Cada indicador possui agora um arquivo de definições
   específico (ex.: `ma_defs.mqh`, `stochastic_defs.mqh`, `bollinger_defs.mqh`) contendo as
   enumerações relacionadas a suas opções, padronizando a organização das
@@ -140,7 +141,7 @@ Esta seção detalha as principais funções e classes encontradas no código do
 
 - **`ExecuteOnNewBar()`**
   - **Assinatura**: `void ExecuteOnNewBar()`
-  - **Descrição simplificada**: Contém a lógica a ser executada quando um novo candle é detectado. Agora os contextos configurados no JSON para o símbolo "WIN$N" são obtidos de forma dinâmica. Cada contexto é atualizado automaticamente e são impressas informações específicas, como as EMAs no timeframe D1 ou a linha de tendência do H1.
+  - **Descrição simplificada**: Contém a lógica a ser executada quando um novo candle é detectado. Todos os contextos configurados para o símbolo "WIN$N" são atualizados e o módulo `CTrendIdentifier` determina se a tendência geral está de alta, baixa ou neutra.
   - **Parâmetros**: Nenhum.
   - **Valor de retorno**: Nenhum.
 
@@ -988,6 +989,7 @@ Esta seção registra as principais alterações e versões dos componentes do E
 ### PA_WIN.mq5
 
 -   **Versão 2.00 (22.06.2025)**: Atualizado para integrar o `ConfigManager` para gerenciamento de configurações externas via JSON.
+-   **Versão 2.01**: `ExecuteOnNewBar` passa a atualizar todos os contextos e utiliza `CTrendIdentifier` para indicar a tendência do mercado.
 
 ### JAson.mqh
 
@@ -1048,3 +1050,8 @@ Esta seção registra as principais alterações e versões dos componentes do E
 
 -   **Versao 1.00**: Implementa o indicador de retração de Fibonacci derivado de `CIndicatorBase`.
 -   **Versao 2.00**: Suporte a extensões, estilos configuráveis e rótulos personalizados via JSON.
+
+### trend_identifier.mqh
+
+-   **Versao 1.00**: Primeiro módulo para avaliar a direção predominante do mercado utilizando EMAs de múltiplos timeframes, VWAP e Bandas de Bollinger.
+-   **Versao 1.01**: Comentários explicativos baseados no eBook de tendência para WINM25.


### PR DESCRIPTION
## Summary
- document trend detection rules inside `trend_identifier.mqh`
- reference the WINM25 ebook in docs and changelog

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6869e1fb49e08320b185a660b0f6dd5d