### PR TITLE
Add trendline candle analysis features

### DIFF
--- a/PA_WIN.mq5
+++ b/PA_WIN.mq5
@@ -15,7 +15,7 @@
 CConfigManager *g_config_manager;
 
 // Parâmetros de entrada
-input string JsonConfigFile = "config.json"; // Nome do arquivo JSON 
+input string JsonConfigFile = "config.json"; // Nome do arquivo JSON
 
 // Variáveis para controle de novo candle
 datetime m_last_bar_time;     // Tempo do último candle processado
@@ -123,40 +123,81 @@ void UpdateSymbolContexts(string symbol)
    TF_CTX *contexts[];
    ENUM_TIMEFRAMES tfs[];
    int count = g_config_manager.GetSymbolContexts(symbol, contexts, tfs);
-
-   if(count==0)
+   if (count == 0)
    {
       Print("AVISO: Nenhum contexto encontrado para símbolo: ", symbol);
       return;
    }
-
-   for(int i=0;i<count;i++)
+   for (int i = 0; i < count; i++)
    {
       TF_CTX *ctx = contexts[i];
       ENUM_TIMEFRAMES tf = tfs[i];
-
-      if(ctx==NULL)
+      if (ctx == NULL)
          continue;
       ctx.Update();
-
-      if(tf==PERIOD_H1)
+      if (tf == PERIOD_H1)
       {
          CPriceActionBase *pa = ctx.GetPriceAction("swing_lines");
-         if(pa!=NULL)
+         if (pa != NULL)
          {
-            CTrendLine *tl = (CTrendLine*)pa;
+            CTrendLine *tl = (CTrendLine *)pa;
             string pos = tl.GetPricePositionString();
-            if(pos!="")
-               Print("Posicao do preco em H1: ",pos);
-
+            if (pos != "")
+               Print("Posicao do preco em H1: ", pos);
+           
             CTrendLine::SCandleFullInfo cd = tl.GetCandleFullInfo(1);
-            PrintFormat("Candle[1] %s O:%f H:%f L:%f C:%f body_cross_lta=%d body_cross_ltb=%d between_ltas=%d between_ltbs=%d",
-                        TimeToString(cd.time,TIME_DATE|TIME_MINUTES),
-                        cd.open,cd.high,cd.low,cd.close,
-                        cd.trend.body_cross_lta,
-                        cd.trend.body_cross_ltb,
-                        cd.trend.between_ltas,
-                        cd.trend.between_ltbs);
+           
+            // Cabeçalho da análise do candle
+            Print("========== ANÁLISE CANDLE[1] - H1 ==========");
+           
+            // Informações de cruzamento do corpo
+            Print("CRUZAMENTOS DO CORPO:");
+            PrintFormat("  • LTA: %s | LTA2: %s",
+                       cd.trend.body_cross_lta ? "SIM" : "NÃO",
+                       cd.trend.body_cross_lta2 ? "SIM" : "NÃO");
+            PrintFormat("  • LTB: %s | LTB2: %s",
+                       cd.trend.body_cross_ltb ? "SIM" : "NÃO",
+                       cd.trend.body_cross_ltb2 ? "SIM" : "NÃO");
+           
+            // Posicionamento entre linhas
+            Print("POSICIONAMENTO:");
+            PrintFormat("  • Entre LTAs: %s",
+                       cd.trend.between_ltas ? "SIM" : "NÃO");
+            PrintFormat("  • Entre LTBs: %s",
+                       cd.trend.between_ltbs ? "SIM" : "NÃO");
+           
+            // Posicionamento nas linhas
+            Print("POSIÇÃO NAS LINHAS:");
+            PrintFormat("  • LTA Superior: %s | LTA Inferior: %s",
+                       cd.trend.on_lta_upper ? "SIM" : "NÃO",
+                       cd.trend.on_lta_lower ? "SIM" : "NÃO");
+            PrintFormat("  • LTA2 Superior: %s | LTA2 Inferior: %s",
+                       cd.trend.on_lta2_upper ? "SIM" : "NÃO",
+                       cd.trend.on_lta2_lower ? "SIM" : "NÃO");
+            PrintFormat("  • LTB Superior: %s | LTB Inferior: %s",
+                       cd.trend.on_ltb_upper ? "SIM" : "NÃO",
+                       cd.trend.on_ltb_lower ? "SIM" : "NÃO");
+            PrintFormat("  • LTB2 Superior: %s | LTB2 Inferior: %s",
+                       cd.trend.on_ltb2_upper ? "SIM" : "NÃO",
+                       cd.trend.on_ltb2_lower ? "SIM" : "NÃO");
+           
+            // Distâncias
+            Print("DISTÂNCIAS DO FECHAMENTO:");
+            PrintFormat("  • LTA: %.5f | LTA2: %.5f",
+                       cd.trend.dist_close_lta, cd.trend.dist_close_lta2);
+            PrintFormat("  • LTB: %.5f | LTB2: %.5f",
+                       cd.trend.dist_close_ltb, cd.trend.dist_close_ltb2);
+           
+            // Fakeouts
+            Print("FAKEOUTS:");
+            PrintFormat("  • LTA: %s | LTA2: %s",
+                       cd.trend.fakeout_lta ? "SIM" : "NÃO",
+                       cd.trend.fakeout_lta2 ? "SIM" : "NÃO");
+            PrintFormat("  • LTB: %s | LTB2: %s",
+                       cd.trend.fakeout_ltb ? "SIM" : "NÃO",
+                       cd.trend.fakeout_ltb2 ? "SIM" : "NÃO");
+           
+            Print("==========================================");
          }
       }
    }
@@ -173,7 +214,7 @@ void ExecuteOnNewBar()
    string symbols[];
    g_config_manager.GetConfiguredSymbols(symbols);
 
-   for(int i=0; i<ArraySize(symbols); i++)
+   for (int i = 0; i < ArraySize(symbols); i++)
    {
       UpdateSymbolContexts(symbols[i]);
    }

--- a/PA_WIN.mq5
+++ b/PA_WIN.mq5
@@ -148,6 +148,15 @@ void UpdateSymbolContexts(string symbol)
             string pos = tl.GetPricePositionString();
             if(pos!="")
                Print("Posicao do preco em H1: ",pos);
+
+            CTrendLine::SCandleFullInfo cd = tl.GetCandleFullInfo(1);
+            PrintFormat("Candle[1] %s O:%f H:%f L:%f C:%f body_cross_lta=%d body_cross_ltb=%d between_ltas=%d between_ltbs=%d",
+                        TimeToString(cd.time,TIME_DATE|TIME_MINUTES),
+                        cd.open,cd.high,cd.low,cd.close,
+                        cd.trend.body_cross_lta,
+                        cd.trend.body_cross_ltb,
+                        cd.trend.between_ltas,
+                        cd.trend.between_ltbs);
          }
       }
    }

--- a/TF_CTX/config_manager.mqh
+++ b/TF_CTX/config_manager.mqh
@@ -712,7 +712,37 @@ CPriceActionConfig *CConfigManager::CreatePriceActionConfig(CJAVal *pa, ENUM_TIM
         p.ltb_width=(int)pa["ltb_width"].ToInt();
         p.extend_right=pa["extend_right"].ToBool();
         p.alert_tf=StringToTimeframe(pa["alert_tf"].ToStr());
-        p.min_angle=pa["min_angle"].ToDbl();
+      p.min_angle=pa["min_angle"].ToDbl();
+
+      p.candles_lookback=(int)pa["trendline_candles_lookback"].ToInt();
+      CJAVal *flags=pa["trendline_status_flags"];
+      if(flags!=NULL)
+        {
+         p.status_flags.enable_body_cross=flags["enable_body_cross"].ToBool();
+         p.status_flags.enable_between_ltas=flags["enable_between_ltas"].ToBool();
+         p.status_flags.enable_between_ltbs=flags["enable_between_ltbs"].ToBool();
+         p.status_flags.enable_distance_points=flags["enable_distance_points"].ToBool();
+        }
+
+      CJAVal *ctx=pa["trendline_context_analysis"];
+      if(ctx!=NULL)
+        {
+         p.context_analysis.enabled=ctx["enabled"].ToBool();
+         p.context_analysis.lookback=(int)ctx["lookback"].ToInt();
+         p.context_analysis.trend_threshold=ctx["trend_threshold"].ToDbl();
+         p.context_analysis.consolidation_threshold=ctx["consolidation_threshold"].ToDbl();
+        }
+
+      CJAVal *adv=pa["trendline_advanced_features"];
+      if(adv!=NULL)
+        {
+         p.advanced_features.detect_fakeout=adv["detect_fakeout"].ToBool();
+         p.advanced_features.count_touches=adv["count_touches"].ToBool();
+         p.advanced_features.touch_tolerance_points=adv["touch_tolerance_points"].ToDbl();
+         string mode=adv["status_evaluate_mode"].ToStr();
+         if(StringLen(mode)>0) p.advanced_features.status_evaluate_mode=mode;
+         p.advanced_features.register_resets=adv["register_resets"].ToBool();
+        }
 
         if(p.alert_tf==PERIOD_CURRENT)   p.alert_tf=ctx_tf;
         return p;

--- a/TF_CTX/config_types.mqh
+++ b/TF_CTX/config_types.mqh
@@ -135,6 +135,54 @@ public:
    virtual ~CPriceActionConfig(){}
   };
 
+//--- Additional structs for TrendLine advanced options
+struct TrendlineStatusFlags
+  {
+   bool enable_body_cross;
+   bool enable_between_ltas;
+   bool enable_between_ltbs;
+   bool enable_distance_points;
+   TrendlineStatusFlags()
+     {
+      enable_body_cross=true;
+      enable_between_ltas=true;
+      enable_between_ltbs=true;
+      enable_distance_points=true;
+     }
+  };
+
+struct TrendlineContextConfig
+  {
+   bool   enabled;
+   int    lookback;
+   double trend_threshold;
+   double consolidation_threshold;
+   TrendlineContextConfig()
+     {
+      enabled=false;
+      lookback=9;
+      trend_threshold=0.7;
+      consolidation_threshold=0.6;
+     }
+  };
+
+struct TrendlineAdvancedFeatures
+  {
+   bool   detect_fakeout;
+   bool   count_touches;
+   double touch_tolerance_points;
+   string status_evaluate_mode;
+   bool   register_resets;
+   TrendlineAdvancedFeatures()
+     {
+      detect_fakeout=false;
+      count_touches=false;
+      touch_tolerance_points=0.0;
+      status_evaluate_mode="close_only";
+      register_resets=false;
+     }
+  };
+
 //--- TrendLine configuration
 class CTrendLineConfig : public CPriceActionConfig
   {
@@ -153,6 +201,10 @@ public:
   bool   extend_right;
   ENUM_TIMEFRAMES alert_tf;
   double min_angle;
+  int    candles_lookback;
+  TrendlineStatusFlags   status_flags;
+  TrendlineContextConfig context_analysis;
+  TrendlineAdvancedFeatures advanced_features;
   CTrendLineConfig()
     {
       period=20; pivot_left=3; pivot_right=3; draw_lta=true; draw_ltb=true;
@@ -161,6 +213,7 @@ public:
       lta_width=1; ltb_width=1; extend_right=true;
       alert_tf=PERIOD_H1;
       min_angle=20.0;
+      candles_lookback=9;
     }
   };
 

--- a/TF_CTX/priceaction/trendline/trendline.mqh
+++ b/TF_CTX/priceaction/trendline/trendline.mqh
@@ -82,8 +82,6 @@ private:
     TrendlineContextConfig m_context_cfg;
     TrendlineAdvancedFeatures m_adv_features;
 
-    // buffer to store candle analysis
-    SCandleTrendInfo m_candle_info[];
     int              m_lta_resets;
     int              m_ltb_resets;
 
@@ -149,7 +147,8 @@ public:
      double   low;
      double   close;
      SCandleTrendInfo trend;
-    };
+  };
+  SCandleTrendInfo m_candle_info[];
   CTrendLine();
   ~CTrendLine();
 

--- a/TF_CTX/priceaction/trendline/trendline.mqh
+++ b/TF_CTX/priceaction/trendline/trendline.mqh
@@ -56,59 +56,58 @@ private:
   double m_closes[];
 
   // informações da LTA ativa
-  bool     m_lta_active;
-  bool     m_lta2_active;
+  bool m_lta_active;
+  bool m_lta2_active;
   datetime m_lta_t1; // pivô mais antigo
   datetime m_lta_t2; // pivô mais recente
-  double   m_lta_p1;   // corpo do primeiro fundo
-  double   m_lta_p2;   // minima do segundo fundo
-  double   m_lta2_p1;  // minima do primeiro fundo
-  double   m_lta2_p2;  // corpo do segundo fundo
+  double m_lta_p1;   // corpo do primeiro fundo
+  double m_lta_p2;   // minima do segundo fundo
+  double m_lta2_p1;  // minima do primeiro fundo
+  double m_lta2_p2;  // corpo do segundo fundo
   datetime m_lta_last_break;
 
   // informações da LTB ativa
-  bool     m_ltb_active;
-  bool     m_ltb2_active;
+  bool m_ltb_active;
+  bool m_ltb2_active;
   datetime m_ltb_t1;
   datetime m_ltb_t2;
-  double   m_ltb_p1;   // corpo do primeiro topo
-  double   m_ltb_p2;   // maxima do segundo topo
-  double   m_ltb2_p1;  // maxima do primeiro topo
-  double   m_ltb2_p2;  // corpo do segundo topo
-    datetime m_ltb_last_break;
+  double m_ltb_p1;  // corpo do primeiro topo
+  double m_ltb_p2;  // maxima do segundo topo
+  double m_ltb2_p1; // maxima do primeiro topo
+  double m_ltb2_p2; // corpo do segundo topo
+  datetime m_ltb_last_break;
 
-    int     m_candles_lookback;
-    TrendlineStatusFlags   m_status_flags;
-    TrendlineContextConfig m_context_cfg;
-    TrendlineAdvancedFeatures m_adv_features;
+  int m_candles_lookback;
+  TrendlineStatusFlags m_status_flags;
+  TrendlineContextConfig m_context_cfg;
+  TrendlineAdvancedFeatures m_adv_features;
 
-    int              m_lta_resets;
-    int              m_ltb_resets;
-
+  int m_lta_resets;
+  int m_ltb_resets;
 
   void DrawLines(datetime t1, double p1, datetime t2, double p2,
                  ENUM_TRENDLINE_SIDE side);
   void RemoveLine(ENUM_TRENDLINE_SIDE side);
   bool CheckBreakLTA();
   bool CheckBreakLTB();
-  bool FindNewPivots(const double &buffer[],int &idx1,int &idx2,double &p1,double &p2,
-                     int left,int right,datetime last_break,bool isHigh);
+  bool FindNewPivots(const double &buffer[], int &idx1, int &idx2, double &p1, double &p2,
+                     int left, int right, datetime last_break, bool isHigh);
   void UpdateTrendlineLTA();
   void UpdateTrendlineLTB();
-  void CalculateBases(int idx_old,int idx_new,double p_old,double p_new,
-                      double &base_old,double &base_new);
-  void CalculateMetrics(int idx_old,int idx_new,double base_old,double p_old,double p_new,double base_new,
-                        double &slope,double &slope2,double &angle,double &angle2);
+  void CalculateBases(int idx_old, int idx_new, double p_old, double p_new,
+                      double &base_old, double &base_new);
+  void CalculateMetrics(int idx_old, int idx_new, double base_old, double p_old, double p_new, double base_new,
+                        double &slope, double &slope2, double &angle, double &angle2);
   void ResetLTA();
   void ResetLTB();
   string GetObjectName(ENUM_TRENDLINE_SIDE side);
-  void   GetDrawSettings(ENUM_TRENDLINE_SIDE side,color &col,ENUM_LINE_STYLE &st,int &width);
-  bool   CheckBreak(ENUM_TRENDLINE_SIDE side);
-  bool   IsPivot(const double &buffer[],int index,int left,int right,bool isHigh);
-    int    GetBarsCount();
-    double GetLineValue(int shift,ENUM_TRENDLINE_SIDE side,double current);
+  void GetDrawSettings(ENUM_TRENDLINE_SIDE side, color &col, ENUM_LINE_STYLE &st, int &width);
+  bool CheckBreak(ENUM_TRENDLINE_SIDE side);
+  bool IsPivot(const double &buffer[], int index, int left, int right, bool isHigh);
+  int GetBarsCount();
+  double GetLineValue(int shift, ENUM_TRENDLINE_SIDE side, double current);
 
-    void   UpdateCandleAnalysis();
+  void UpdateCandleAnalysis();
   //+------------------------------------------------------------------+
   //| Calcula o slope entre dois pontos usando índices de barra         |
   //+------------------------------------------------------------------+
@@ -122,31 +121,52 @@ private:
 public:
   // Informações detalhadas de candles em relação às linhas
   struct SCandleTrendInfo
-    {
-     bool body_cross_lta;
-     bool body_cross_ltb;
-     bool between_ltas;
-     bool between_ltbs;
-     bool on_lta_upper;
-     bool on_lta_lower;
-     bool on_ltb_upper;
-     bool on_ltb_lower;
-     double dist_close_lta;
-     double dist_close_ltb;
-     double dist_close_lta2;
-     double dist_close_ltb2;
-     bool fakeout_lta;
-     bool fakeout_ltb;
-    };
+  {
+    bool body_cross_lta;
+    bool body_cross_ltb;
+    bool between_ltas;
+    bool between_ltbs;
+    bool on_lta_upper;
+    bool on_lta_lower;
+    bool on_ltb_upper;
+    bool on_ltb_lower;
+    double dist_close_lta;
+    double dist_close_ltb;
+    double dist_close_lta2;
+    double dist_close_ltb2;
+
+    bool body_cross_lta2;
+    bool body_cross_ltb2;
+    bool on_lta2_upper;
+    bool on_lta2_lower;
+    bool on_ltb2_upper;
+    bool on_ltb2_lower;
+    bool fakeout_lta2;
+    bool fakeout_ltb2;
+
+    // O que caracteriza um fakeout neste EA:
+    // Para LTA (Linha de Tendência de Alta):
+
+    // Fakeout de baixa: (l<val && c>val) - A mínima do candle rompeu abaixo da LTA, mas o fechamento ficou acima da linha
+    // Fakeout de alta: (h>val && c<val) - A máxima tocou acima da LTA, mas o fechamento ficou abaixo
+
+    // Para LTB (Linha de Tendência de Baixa):
+
+    // Fakeout de alta: (h>val && c<val) - A máxima rompeu acima da LTB, mas o fechamento ficou abaixo da linha
+    // Fakeout de baixa: (l<val && c>val) - A mínima tocou abaixo da LTB, mas o fechamento ficou acima
+
+    bool fakeout_lta;
+    bool fakeout_ltb;
+  };
 
   struct SCandleFullInfo
-    {
-     datetime time;
-     double   open;
-     double   high;
-     double   low;
-     double   close;
-     SCandleTrendInfo trend;
+  {
+    datetime time;
+    double open;
+    double high;
+    double low;
+    double close;
+    SCandleTrendInfo trend;
   };
   SCandleTrendInfo m_candle_info[];
   CTrendLine();
@@ -172,8 +192,8 @@ public:
   ENUM_TREND_POSITION GetPricePosition();
   string GetPricePositionString();
   SCandleTrendInfo GetCandleInfo(int shift);
-  double GetDistanceToLine(int shift,ENUM_TRENDLINE_SIDE side);
-  SCandleFullInfo  GetCandleFullInfo(int shift);
+  double GetDistanceToLine(int shift, ENUM_TRENDLINE_SIDE side);
+  SCandleFullInfo GetCandleFullInfo(int shift);
 };
 
 //+------------------------------------------------------------------+
@@ -217,17 +237,20 @@ CTrendLine::CTrendLine()
   ArrayResize(m_closes, 0);
   ResetLTA();
   ResetLTB();
-  m_lta_last_break=0;
-    m_ltb_last_break=0;
-    m_candles_lookback=9;
-    m_lta_resets=0;
-    m_ltb_resets=0;
-    ArrayResize(m_candle_info,0);
-    // default advanced configs
-    TrendlineStatusFlags tmp_flags; m_status_flags=tmp_flags;
-    TrendlineContextConfig tmp_ctx; m_context_cfg=tmp_ctx;
-    TrendlineAdvancedFeatures tmp_adv; m_adv_features=tmp_adv;
-  }
+  m_lta_last_break = 0;
+  m_ltb_last_break = 0;
+  m_candles_lookback = 9;
+  m_lta_resets = 0;
+  m_ltb_resets = 0;
+  ArrayResize(m_candle_info, 0);
+  // default advanced configs
+  TrendlineStatusFlags tmp_flags;
+  m_status_flags = tmp_flags;
+  TrendlineContextConfig tmp_ctx;
+  m_context_cfg = tmp_ctx;
+  TrendlineAdvancedFeatures tmp_adv;
+  m_adv_features = tmp_adv;
+}
 
 //+------------------------------------------------------------------+
 //| Destructor                                                        |
@@ -239,7 +262,6 @@ CTrendLine::~CTrendLine()
   RemoveLine(TRENDLINE_LTA2);
   RemoveLine(TRENDLINE_LTB2);
 }
-
 
 //+------------------------------------------------------------------+
 //| Init using config                                                 |
@@ -259,13 +281,13 @@ bool CTrendLine::Init(string symbol, ENUM_TIMEFRAMES timeframe, CTrendLineConfig
   m_ltb_style = cfg.ltb_style;
   m_lta_width = cfg.lta_width;
   m_ltb_width = cfg.ltb_width;
-    m_extend_right = cfg.extend_right;
-    m_alert_tf = cfg.alert_tf;
-    m_min_angle = cfg.min_angle;
-    m_candles_lookback = cfg.candles_lookback;
-    m_status_flags = cfg.status_flags;
-    m_context_cfg  = cfg.context_analysis;
-    m_adv_features = cfg.advanced_features;
+  m_extend_right = cfg.extend_right;
+  m_alert_tf = cfg.alert_tf;
+  m_min_angle = cfg.min_angle;
+  m_candles_lookback = cfg.candles_lookback;
+  m_status_flags = cfg.status_flags;
+  m_context_cfg = cfg.context_analysis;
+  m_adv_features = cfg.advanced_features;
 
   bool ok = true;
   m_obj_lta = "TL_LTA_" + IntegerToString(GetTickCount());
@@ -276,20 +298,22 @@ bool CTrendLine::Init(string symbol, ENUM_TIMEFRAMES timeframe, CTrendLineConfig
   ArrayResize(m_highs, bars);
   ArrayResize(m_lows, bars);
   ArrayResize(m_closes, 2); // only need last two closes
-    ArraySetAsSeries(m_highs, true);
-    ArraySetAsSeries(m_lows, true);
-    ArraySetAsSeries(m_closes, true);
-    ArrayResize(m_candle_info,m_candles_lookback);
-    ArraySetAsSeries(m_candle_info,true);
-  m_lta_angle = 0.0;   m_lta2_angle = 0.0;
-  m_ltb_angle = 0.0;   m_ltb2_angle = 0.0;
+  ArraySetAsSeries(m_highs, true);
+  ArraySetAsSeries(m_lows, true);
+  ArraySetAsSeries(m_closes, true);
+  ArrayResize(m_candle_info, m_candles_lookback);
+  ArraySetAsSeries(m_candle_info, true);
+  m_lta_angle = 0.0;
+  m_lta2_angle = 0.0;
+  m_ltb_angle = 0.0;
+  m_ltb2_angle = 0.0;
   ResetLTA();
   ResetLTB();
-  m_lta_last_break=0;
-    m_ltb_last_break=0;
-    UpdateCandleAnalysis();
-    return ok;
-  }
+  m_lta_last_break = 0;
+  m_ltb_last_break = 0;
+  UpdateCandleAnalysis();
+  return ok;
+}
 
 //+------------------------------------------------------------------+
 //| Default init                                                      |
@@ -333,9 +357,11 @@ bool CTrendLine::IsReady()
 //+------------------------------------------------------------------+
 void CTrendLine::DrawLines(datetime t1, double p1, datetime t2, double p2, ENUM_TRENDLINE_SIDE side)
 {
-  string name=GetObjectName(side);
-  color col; ENUM_LINE_STYLE st; int width;
-  GetDrawSettings(side,col,st,width);
+  string name = GetObjectName(side);
+  color col;
+  ENUM_LINE_STYLE st;
+  int width;
+  GetDrawSettings(side, col, st, width);
   if (ObjectFind(0, name) < 0)
     ObjectCreate(0, name, OBJ_TREND, 0, t1, p1, t2, p2);
   else
@@ -349,9 +375,9 @@ void CTrendLine::DrawLines(datetime t1, double p1, datetime t2, double p2, ENUM_
 
 void CTrendLine::RemoveLine(ENUM_TRENDLINE_SIDE side)
 {
-  string name=GetObjectName(side);
-  if(ObjectFind(0,name) >= 0)
-     ObjectDelete(0,name);
+  string name = GetObjectName(side);
+  if (ObjectFind(0, name) >= 0)
+    ObjectDelete(0, name);
 }
 
 bool CTrendLine::CheckBreakLTA()
@@ -364,289 +390,337 @@ bool CTrendLine::CheckBreakLTB()
   return CheckBreak(TRENDLINE_LTB);
 }
 
-bool CTrendLine::FindNewPivots(const double &buffer[],int &idx_recent,int &idx_old,double &p_recent,double &p_old,
-                               int left,int right,datetime last_break,bool isHigh)
+bool CTrendLine::FindNewPivots(const double &buffer[], int &idx_recent, int &idx_old, double &p_recent, double &p_old,
+                               int left, int right, datetime last_break, bool isHigh)
 {
-  int bars=GetBarsCount();
-  idx_recent=-1; idx_old=-1;
-  for(int i=right; i<bars-left; i++)
+  int bars = GetBarsCount();
+  idx_recent = -1;
+  idx_old = -1;
+  for (int i = right; i < bars - left; i++)
   {
-     if(!IsPivot(buffer,i,left,right,isHigh))
-        continue;
-     datetime tt=iTime(m_symbol,m_timeframe,i);
-     if(tt<=last_break) continue;
-     idx_recent=i; p_recent=buffer[i];
-     break;
+    if (!IsPivot(buffer, i, left, right, isHigh))
+      continue;
+    datetime tt = iTime(m_symbol, m_timeframe, i);
+    if (tt <= last_break)
+      continue;
+    idx_recent = i;
+    p_recent = buffer[i];
+    break;
   }
-  for(int i=idx_recent+right+1; i<bars-left; i++)
+  for (int i = idx_recent + right + 1; i < bars - left; i++)
   {
-     if(!IsPivot(buffer,i,left,right,isHigh))
-        continue;
-     datetime tt=iTime(m_symbol,m_timeframe,i);
-     if(tt<=last_break) continue;
-     idx_old=i; p_old=buffer[i];
-     break;
+    if (!IsPivot(buffer, i, left, right, isHigh))
+      continue;
+    datetime tt = iTime(m_symbol, m_timeframe, i);
+    if (tt <= last_break)
+      continue;
+    idx_old = i;
+    p_old = buffer[i];
+    break;
   }
-  return (idx_recent>0 && idx_old>0);
+  return (idx_recent > 0 && idx_old > 0);
 }
 
-void CTrendLine::CalculateBases(int idx_old,int idx_new,double p_old,double p_new,
-                                double &base_old,double &base_new)
+void CTrendLine::CalculateBases(int idx_old, int idx_new, double p_old, double p_new,
+                                double &base_old, double &base_new)
 {
-  double open_old=iOpen(m_symbol,m_timeframe,idx_old);
-  double close_old=iClose(m_symbol,m_timeframe,idx_old);
-  base_old=(MathAbs(open_old-p_old)<MathAbs(close_old-p_old)?open_old:close_old);
-  double open_new=iOpen(m_symbol,m_timeframe,idx_new);
-  double close_new=iClose(m_symbol,m_timeframe,idx_new);
-  base_new=(MathAbs(open_new-p_new)<MathAbs(close_new-p_new)?open_new:close_new);
+  double open_old = iOpen(m_symbol, m_timeframe, idx_old);
+  double close_old = iClose(m_symbol, m_timeframe, idx_old);
+  base_old = (MathAbs(open_old - p_old) < MathAbs(close_old - p_old) ? open_old : close_old);
+  double open_new = iOpen(m_symbol, m_timeframe, idx_new);
+  double close_new = iClose(m_symbol, m_timeframe, idx_new);
+  base_new = (MathAbs(open_new - p_new) < MathAbs(close_new - p_new) ? open_new : close_new);
 }
 
-void CTrendLine::CalculateMetrics(int idx_old,int idx_new,double base_old,double p_old,double p_new,double base_new,
-                                  double &slope,double &slope2,double &angle,double &angle2)
+void CTrendLine::CalculateMetrics(int idx_old, int idx_new, double base_old, double p_old, double p_new, double base_new,
+                                  double &slope, double &slope2, double &angle, double &angle2)
 {
-  slope=CalcSlope(idx_old,base_old,idx_new,p_new);
-  slope2=CalcSlope(idx_old,p_old,idx_new,base_new);
-  angle=MathArctan2(p_new-base_old,idx_new-idx_old)*180.0/M_PI;
-  angle2=MathArctan2(base_new-p_old,idx_new-idx_old)*180.0/M_PI;
-  if(angle<0) angle=-angle;
-  if(angle2<0) angle2=-angle2;
+  slope = CalcSlope(idx_old, base_old, idx_new, p_new);
+  slope2 = CalcSlope(idx_old, p_old, idx_new, base_new);
+  angle = MathArctan2(p_new - base_old, idx_new - idx_old) * 180.0 / M_PI;
+  angle2 = MathArctan2(base_new - p_old, idx_new - idx_old) * 180.0 / M_PI;
+  if (angle < 0)
+    angle = -angle;
+  if (angle2 < 0)
+    angle2 = -angle2;
 }
 
 void CTrendLine::ResetLTA()
 {
   RemoveLine(TRENDLINE_LTA);
   RemoveLine(TRENDLINE_LTA2);
-  m_lta_active=false; m_lta2_active=false;
-  m_lta_t1=0; m_lta_t2=0; m_lta_p1=0.0; m_lta_p2=0.0; m_lta2_p1=0.0; m_lta2_p2=0.0;
-  m_lta_val=0.0; m_lta2_val=0.0;
-  m_lta_angle=0.0; m_lta2_angle=0.0;
+  m_lta_active = false;
+  m_lta2_active = false;
+  m_lta_t1 = 0;
+  m_lta_t2 = 0;
+  m_lta_p1 = 0.0;
+  m_lta_p2 = 0.0;
+  m_lta2_p1 = 0.0;
+  m_lta2_p2 = 0.0;
+  m_lta_val = 0.0;
+  m_lta2_val = 0.0;
+  m_lta_angle = 0.0;
+  m_lta2_angle = 0.0;
 }
 
 void CTrendLine::ResetLTB()
 {
   RemoveLine(TRENDLINE_LTB);
   RemoveLine(TRENDLINE_LTB2);
-  m_ltb_active=false; m_ltb2_active=false;
-  m_ltb_t1=0; m_ltb_t2=0; m_ltb_p1=0.0; m_ltb_p2=0.0; m_ltb2_p1=0.0; m_ltb2_p2=0.0;
-  m_ltb_val=0.0; m_ltb2_val=0.0;
-  m_ltb_angle=0.0; m_ltb2_angle=0.0;
+  m_ltb_active = false;
+  m_ltb2_active = false;
+  m_ltb_t1 = 0;
+  m_ltb_t2 = 0;
+  m_ltb_p1 = 0.0;
+  m_ltb_p2 = 0.0;
+  m_ltb2_p1 = 0.0;
+  m_ltb2_p2 = 0.0;
+  m_ltb_val = 0.0;
+  m_ltb2_val = 0.0;
+  m_ltb_angle = 0.0;
+  m_ltb2_angle = 0.0;
 }
 
 string CTrendLine::GetObjectName(ENUM_TRENDLINE_SIDE side)
 {
-  switch(side)
+  switch (side)
   {
-    case TRENDLINE_LTA:  return m_obj_lta;
-    case TRENDLINE_LTB:  return m_obj_ltb;
-    case TRENDLINE_LTA2: return m_obj_lta2;
-    case TRENDLINE_LTB2: return m_obj_ltb2;
-    default:             return "";
+  case TRENDLINE_LTA:
+    return m_obj_lta;
+  case TRENDLINE_LTB:
+    return m_obj_ltb;
+  case TRENDLINE_LTA2:
+    return m_obj_lta2;
+  case TRENDLINE_LTB2:
+    return m_obj_ltb2;
+  default:
+    return "";
   }
 }
 
-void CTrendLine::GetDrawSettings(ENUM_TRENDLINE_SIDE side,color &col,ENUM_LINE_STYLE &st,int &width)
+void CTrendLine::GetDrawSettings(ENUM_TRENDLINE_SIDE side, color &col, ENUM_LINE_STYLE &st, int &width)
 {
-  switch(side)
+  switch (side)
   {
-    case TRENDLINE_LTA:
-    case TRENDLINE_LTA2:
-      col=m_lta_color; st=m_lta_style; width=m_lta_width; break;
-    case TRENDLINE_LTB:
-    case TRENDLINE_LTB2:
-      col=m_ltb_color; st=m_ltb_style; width=m_ltb_width; break;
-    default:
-      col=clrWhite; st=STYLE_SOLID; width=1; break;
+  case TRENDLINE_LTA:
+  case TRENDLINE_LTA2:
+    col = m_lta_color;
+    st = m_lta_style;
+    width = m_lta_width;
+    break;
+  case TRENDLINE_LTB:
+  case TRENDLINE_LTB2:
+    col = m_ltb_color;
+    st = m_ltb_style;
+    width = m_ltb_width;
+    break;
+  default:
+    col = clrWhite;
+    st = STYLE_SOLID;
+    width = 1;
+    break;
   }
 }
 
-bool CTrendLine::IsPivot(const double &buffer[],int index,int left,int right,bool isHigh)
+bool CTrendLine::IsPivot(const double &buffer[], int index, int left, int right, bool isHigh)
 {
-  for(int j=1;j<=left;j++)
-     if(isHigh?buffer[index]<=buffer[index+j]:buffer[index]>=buffer[index+j])
-        return false;
-  for(int j=1;j<=right;j++)
-     if(isHigh?buffer[index]<buffer[index-j]:buffer[index]>buffer[index-j])
-        return false;
+  for (int j = 1; j <= left; j++)
+    if (isHigh ? buffer[index] <= buffer[index + j] : buffer[index] >= buffer[index + j])
+      return false;
+  for (int j = 1; j <= right; j++)
+    if (isHigh ? buffer[index] < buffer[index - j] : buffer[index] > buffer[index - j])
+      return false;
   return true;
 }
 
 int CTrendLine::GetBarsCount()
 {
-  return (m_period>0)?m_period:50;
+  return (m_period > 0) ? m_period : 50;
 }
 
-double CTrendLine::GetLineValue(int shift,ENUM_TRENDLINE_SIDE side,double current)
+double CTrendLine::GetLineValue(int shift, ENUM_TRENDLINE_SIDE side, double current)
 {
-  if(shift==0)
-     return current;
-  datetime t=iTime(m_symbol,m_alert_tf,shift);
-  if(t==0)
-     return 0.0;
-  string name=GetObjectName(side);
-  return ObjectGetValueByTime(0,name,t);
+  if (shift == 0)
+    return current;
+  datetime t = iTime(m_symbol, m_alert_tf, shift);
+  if (t == 0)
+    return 0.0;
+  string name = GetObjectName(side);
+  return ObjectGetValueByTime(0, name, t);
 }
 
 bool CTrendLine::CheckBreak(ENUM_TRENDLINE_SIDE side)
 {
-  bool active=(side==TRENDLINE_LTA)?m_lta_active:m_ltb_active;
-  if(!active)
-     return false;
-  datetime t=iTime(m_symbol,m_alert_tf,1);
-  if(t==0)
-     return false;
-  string name=GetObjectName(side);
-  double val=ObjectGetValueByTime(0,name,t);
-  double close=iClose(m_symbol,m_alert_tf,1);
-  bool broke=(side==TRENDLINE_LTA)?(close<val):(close>val);
-  if(!broke)
-     return false;
-  if(side==TRENDLINE_LTA)
-    {
-      ResetLTA();
-      m_lta_last_break=t;
-    }
+  bool active = (side == TRENDLINE_LTA) ? m_lta_active : m_ltb_active;
+  if (!active)
+    return false;
+  datetime t = iTime(m_symbol, m_alert_tf, 1);
+  if (t == 0)
+    return false;
+  string name = GetObjectName(side);
+  double val = ObjectGetValueByTime(0, name, t);
+  double close = iClose(m_symbol, m_alert_tf, 1);
+  bool broke = (side == TRENDLINE_LTA) ? (close < val) : (close > val);
+  if (!broke)
+    return false;
+  if (side == TRENDLINE_LTA)
+  {
+    ResetLTA();
+    m_lta_last_break = t;
+  }
   else
-    {
-      ResetLTB();
-      m_ltb_last_break=t;
-    }
+  {
+    ResetLTB();
+    m_ltb_last_break = t;
+  }
   return true;
 }
 
-
 void CTrendLine::UpdateTrendlineLTB()
 {
-  if(m_ltb_active)
+  if (m_ltb_active)
   {
-     if(CheckBreakLTB())
-        return;
-     int idx_old=iBarShift(m_symbol,m_timeframe,m_ltb_t1,true);
-     int idx_new=iBarShift(m_symbol,m_timeframe,m_ltb_t2,true);
-     double slope=CalcSlope(idx_old,m_ltb_p1,idx_new,m_ltb_p2);
-     double slope2=CalcSlope(idx_old,m_ltb2_p1,idx_new,m_ltb2_p2);
-     m_ltb_val=m_ltb_p2 - slope*idx_new;
-     m_ltb2_val=m_ltb2_p2 - slope2*idx_new;
-     return;
+    if (CheckBreakLTB())
+      return;
+    int idx_old = iBarShift(m_symbol, m_timeframe, m_ltb_t1, true);
+    int idx_new = iBarShift(m_symbol, m_timeframe, m_ltb_t2, true);
+    double slope = CalcSlope(idx_old, m_ltb_p1, idx_new, m_ltb_p2);
+    double slope2 = CalcSlope(idx_old, m_ltb2_p1, idx_new, m_ltb2_p2);
+    m_ltb_val = m_ltb_p2 - slope * idx_new;
+    m_ltb2_val = m_ltb2_p2 - slope2 * idx_new;
+    return;
   }
 
-  int idx_new,idx_old; double p_new,p_old;
-  if(FindNewPivots(m_highs,idx_new,idx_old,p_new,p_old,
-                    m_pivot_left,m_pivot_right,m_ltb_last_break,true))
+  int idx_new, idx_old;
+  double p_new, p_old;
+  if (FindNewPivots(m_highs, idx_new, idx_old, p_new, p_old,
+                    m_pivot_left, m_pivot_right, m_ltb_last_break, true))
+  {
+    int id_old = idx_old;
+    int id_new = idx_new;
+    double base_old, base_new;
+    CalculateBases(id_old, id_new, p_old, p_new, base_old, base_new);
+    double slope, slope2, angle, angle2;
+    CalculateMetrics(id_old, id_new, base_old, p_old, p_new, base_new, slope, slope2, angle, angle2);
+    if (m_draw_ltb && slope < 0 && angle >= m_min_angle)
     {
-      int id_old=idx_old; int id_new=idx_new;
-      double base_old,base_new;
-      CalculateBases(id_old,id_new,p_old,p_new,base_old,base_new);
-      double slope,slope2,angle,angle2;
-      CalculateMetrics(id_old,id_new,base_old,p_old,p_new,base_new,slope,slope2,angle,angle2);
-      if(m_draw_ltb && slope<0 && angle>=m_min_angle)
-        {
-         datetime t1=iTime(m_symbol,m_timeframe,id_old);
-         datetime t2=iTime(m_symbol,m_timeframe,id_new);
-         DrawLines(t1,base_old,t2,p_new,TRENDLINE_LTB);
-         DrawLines(t1,p_old,t2,base_new,TRENDLINE_LTB2);
-         m_ltb_active=true;
-         m_ltb2_active=true;
-         m_ltb_angle=angle;
-         m_ltb2_angle=angle2;
-         m_ltb_t1=t1; m_ltb_t2=t2; m_ltb_p1=base_old; m_ltb_p2=p_new;
-         m_ltb2_p1=p_old; m_ltb2_p2=base_new;
-         m_ltb_val=p_new - slope*id_new;
-         m_ltb2_val=base_new - slope2*id_new;
-        }
+      datetime t1 = iTime(m_symbol, m_timeframe, id_old);
+      datetime t2 = iTime(m_symbol, m_timeframe, id_new);
+      DrawLines(t1, base_old, t2, p_new, TRENDLINE_LTB);
+      DrawLines(t1, p_old, t2, base_new, TRENDLINE_LTB2);
+      m_ltb_active = true;
+      m_ltb2_active = true;
+      m_ltb_angle = angle;
+      m_ltb2_angle = angle2;
+      m_ltb_t1 = t1;
+      m_ltb_t2 = t2;
+      m_ltb_p1 = base_old;
+      m_ltb_p2 = p_new;
+      m_ltb2_p1 = p_old;
+      m_ltb2_p2 = base_new;
+      m_ltb_val = p_new - slope * id_new;
+      m_ltb2_val = base_new - slope2 * id_new;
     }
+  }
 }
 
 void CTrendLine::UpdateTrendlineLTA()
 {
-  if(m_lta_active)
+  if (m_lta_active)
   {
-     if(CheckBreakLTA())
-        return;
-     int idx_old=iBarShift(m_symbol,m_timeframe,m_lta_t1,true);
-     int idx_new=iBarShift(m_symbol,m_timeframe,m_lta_t2,true);
-     double slope=CalcSlope(idx_old,m_lta_p1,idx_new,m_lta_p2);
-     double slope2=CalcSlope(idx_old,m_lta2_p1,idx_new,m_lta2_p2);
-     m_lta_val=m_lta_p2 - slope*idx_new;
-     m_lta2_val=m_lta2_p2 - slope2*idx_new;
-     return;
+    if (CheckBreakLTA())
+      return;
+    int idx_old = iBarShift(m_symbol, m_timeframe, m_lta_t1, true);
+    int idx_new = iBarShift(m_symbol, m_timeframe, m_lta_t2, true);
+    double slope = CalcSlope(idx_old, m_lta_p1, idx_new, m_lta_p2);
+    double slope2 = CalcSlope(idx_old, m_lta2_p1, idx_new, m_lta2_p2);
+    m_lta_val = m_lta_p2 - slope * idx_new;
+    m_lta2_val = m_lta2_p2 - slope2 * idx_new;
+    return;
   }
 
-  int idx_new,idx_old; double p_new,p_old;
-  if(FindNewPivots(m_lows,idx_new,idx_old,p_new,p_old,
-                    m_pivot_left,m_pivot_right,m_lta_last_break,false))
+  int idx_new, idx_old;
+  double p_new, p_old;
+  if (FindNewPivots(m_lows, idx_new, idx_old, p_new, p_old,
+                    m_pivot_left, m_pivot_right, m_lta_last_break, false))
+  {
+    int id_old = idx_old;
+    int id_new = idx_new;
+    double base_old, base_new;
+    CalculateBases(id_old, id_new, p_old, p_new, base_old, base_new);
+    double slope, slope2, angle, angle2;
+    CalculateMetrics(id_old, id_new, base_old, p_old, p_new, base_new, slope, slope2, angle, angle2);
+    if (m_draw_lta && slope > 0 && angle >= m_min_angle)
     {
-      int id_old=idx_old; int id_new=idx_new;
-      double base_old,base_new;
-      CalculateBases(id_old,id_new,p_old,p_new,base_old,base_new);
-      double slope,slope2,angle,angle2;
-      CalculateMetrics(id_old,id_new,base_old,p_old,p_new,base_new,slope,slope2,angle,angle2);
-      if(m_draw_lta && slope>0 && angle>=m_min_angle)
-        {
-         datetime t1=iTime(m_symbol,m_timeframe,id_old);
-         datetime t2=iTime(m_symbol,m_timeframe,id_new);
-         DrawLines(t1,base_old,t2,p_new,TRENDLINE_LTA);
-         DrawLines(t1,p_old,t2,base_new,TRENDLINE_LTA2);
-         m_lta_active=true;
-         m_lta2_active=true;
-         m_lta_angle=angle;
-         m_lta2_angle=angle2;
-         m_lta_t1=t1; m_lta_t2=t2; m_lta_p1=base_old; m_lta_p2=p_new;
-         m_lta2_p1=p_old; m_lta2_p2=base_new;
-         m_lta_val=p_new - slope*id_new;
-         m_lta2_val=base_new - slope2*id_new;
-        }
+      datetime t1 = iTime(m_symbol, m_timeframe, id_old);
+      datetime t2 = iTime(m_symbol, m_timeframe, id_new);
+      DrawLines(t1, base_old, t2, p_new, TRENDLINE_LTA);
+      DrawLines(t1, p_old, t2, base_new, TRENDLINE_LTA2);
+      m_lta_active = true;
+      m_lta2_active = true;
+      m_lta_angle = angle;
+      m_lta2_angle = angle2;
+      m_lta_t1 = t1;
+      m_lta_t2 = t2;
+      m_lta_p1 = base_old;
+      m_lta_p2 = p_new;
+      m_lta2_p1 = p_old;
+      m_lta2_p2 = base_new;
+      m_lta_val = p_new - slope * id_new;
+      m_lta2_val = base_new - slope2 * id_new;
     }
+  }
 }
 
 //+------------------------------------------------------------------+
 //| Update trend line values                                          |
 //+------------------------------------------------------------------+
 bool CTrendLine::Update()
+{
+  int bars = GetBarsCount();
+  int got_high = CopyHigh(m_symbol, m_timeframe, 0, bars, m_highs);
+  int got_low = CopyLow(m_symbol, m_timeframe, 0, bars, m_lows);
+  if (got_high < bars || got_low < bars)
   {
-   int bars = GetBarsCount();
-   int got_high = CopyHigh(m_symbol, m_timeframe, 0, bars, m_highs);
-   int got_low  = CopyLow(m_symbol, m_timeframe, 0, bars, m_lows);
-   if(got_high < bars || got_low < bars)
-     {
-      m_ready=false;
-      return false;
-     }
+    m_ready = false;
+    return false;
+  }
 
-   UpdateTrendlineLTB();
-   UpdateTrendlineLTA();
+  UpdateTrendlineLTB();
+  UpdateTrendlineLTA();
 
-   datetime ct[];
-   ArrayResize(ct,2);
-   ArraySetAsSeries(ct,true);
-   m_breakdown=false;
-   m_breakup=false;
-    if(CopyClose(m_symbol,m_alert_tf,0,2,m_closes)>0 &&
-       CopyTime(m_symbol,m_alert_tf,0,2,ct)>0)
-      {
-      if(m_lta_active)
-        {
-         double sup=ObjectGetValueByTime(0,m_obj_lta,ct[1]);
-         m_breakdown=(m_closes[1]<sup);
-        }
-      if(m_ltb_active)
-        {
-         double res=ObjectGetValueByTime(0,m_obj_ltb,ct[1]);
-         m_breakup=(m_closes[1]>res);
-        }
-      }
+  datetime ct[];
+  ArrayResize(ct, 2);
+  ArraySetAsSeries(ct, true);
+  m_breakdown = false;
+  m_breakup = false;
+  if (CopyClose(m_symbol, m_alert_tf, 0, 2, m_closes) > 0 &&
+      CopyTime(m_symbol, m_alert_tf, 0, 2, ct) > 0)
+  {
+    if (m_lta_active)
+    {
+      double sup = ObjectGetValueByTime(0, m_obj_lta, ct[1]);
+      m_breakdown = (m_closes[1] < sup);
+    }
+    if (m_ltb_active)
+    {
+      double res = ObjectGetValueByTime(0, m_obj_ltb, ct[1]);
+      m_breakup = (m_closes[1] > res);
+    }
+  }
 
-    m_ready=(m_lta_active || m_ltb_active);
-    if(m_ready)
-       UpdateCandleAnalysis();
-    return m_ready;
-   }
+  m_ready = (m_lta_active || m_ltb_active);
+  if (m_ready)
+    UpdateCandleAnalysis();
+  return m_ready;
+}
 
 //+------------------------------------------------------------------+
 //| LTA value                                                         |
 //+------------------------------------------------------------------+
 double CTrendLine::GetLTAValue(int shift)
 {
-  return GetLineValue(shift,TRENDLINE_LTA,m_lta_val);
+  return GetLineValue(shift, TRENDLINE_LTA, m_lta_val);
 }
 
 //+------------------------------------------------------------------+
@@ -654,7 +728,7 @@ double CTrendLine::GetLTAValue(int shift)
 //+------------------------------------------------------------------+
 double CTrendLine::GetLTBValue(int shift)
 {
-  return GetLineValue(shift,TRENDLINE_LTB,m_ltb_val);
+  return GetLineValue(shift, TRENDLINE_LTB, m_ltb_val);
 }
 
 //+------------------------------------------------------------------+
@@ -662,7 +736,7 @@ double CTrendLine::GetLTBValue(int shift)
 //+------------------------------------------------------------------+
 double CTrendLine::GetLTA2Value(int shift)
 {
-  return GetLineValue(shift,TRENDLINE_LTA2,m_lta2_val);
+  return GetLineValue(shift, TRENDLINE_LTA2, m_lta2_val);
 }
 
 //+------------------------------------------------------------------+
@@ -670,7 +744,7 @@ double CTrendLine::GetLTA2Value(int shift)
 //+------------------------------------------------------------------+
 double CTrendLine::GetLTB2Value(int shift)
 {
-  return GetLineValue(shift,TRENDLINE_LTB2,m_ltb2_val);
+  return GetLineValue(shift, TRENDLINE_LTB2, m_ltb2_val);
 }
 
 //+------------------------------------------------------------------+
@@ -688,45 +762,51 @@ bool CTrendLine::IsBreakup() { return m_breakup; }
 //+------------------------------------------------------------------+
 ENUM_TREND_POSITION CTrendLine::GetPricePosition()
 {
-  datetime t=iTime(m_symbol,m_timeframe,1);
-  if(t==0)
-     return TREND_UNKNOWN;
-  double price=iClose(m_symbol,m_timeframe,1);
+  datetime t = iTime(m_symbol, m_timeframe, 1);
+  if (t == 0)
+    return TREND_UNKNOWN;
+  double price = iClose(m_symbol, m_timeframe, 1);
 
-  bool lta=IsLTAValid();
-  bool ltb=IsLTBValid();
-  double lta_val=0.0,ltb_val=0.0;
+  bool lta = IsLTAValid();
+  bool ltb = IsLTBValid();
+  double lta_val = 0.0, ltb_val = 0.0;
 
-  if(lta)
-     lta_val=ObjectGetValueByTime(0,m_obj_lta,t);
-  if(ltb)
-     ltb_val=ObjectGetValueByTime(0,m_obj_ltb,t);
+  if (lta)
+    lta_val = ObjectGetValueByTime(0, m_obj_lta, t);
+  if (ltb)
+    ltb_val = ObjectGetValueByTime(0, m_obj_ltb, t);
 
-  if(lta && ltb)
+  if (lta && ltb)
   {
-     if(price>ltb_val)
-        return TREND_ABOVE_LTB;
-     if(price<lta_val)
-        return TREND_BELOW_LTA;
-     return TREND_BETWEEN;
+    if (price > ltb_val)
+      return TREND_ABOVE_LTB;
+    if (price < lta_val)
+      return TREND_BELOW_LTA;
+    return TREND_BETWEEN;
   }
-  if(lta)
-     return (price>lta_val)?TREND_ABOVE_LTA:TREND_BELOW_LTA;
-  if(ltb)
-     return (price>ltb_val)?TREND_ABOVE_LTB:TREND_BELOW_LTB;
+  if (lta)
+    return (price > lta_val) ? TREND_ABOVE_LTA : TREND_BELOW_LTA;
+  if (ltb)
+    return (price > ltb_val) ? TREND_ABOVE_LTB : TREND_BELOW_LTB;
   return TREND_UNKNOWN;
 }
 
 string CTrendLine::GetPricePositionString()
 {
-  switch(GetPricePosition())
+  switch (GetPricePosition())
   {
-    case TREND_ABOVE_LTB: return "Above LTB";
-    case TREND_BETWEEN:   return "Between LTA and LTB";
-    case TREND_BELOW_LTA: return "Below LTA";
-    case TREND_ABOVE_LTA: return "Above LTA";
-    case TREND_BELOW_LTB: return "Below LTB";
-    default:              return "Unknown";
+  case TREND_ABOVE_LTB:
+    return "Above LTB";
+  case TREND_BETWEEN:
+    return "Between LTA and LTB";
+  case TREND_BELOW_LTA:
+    return "Below LTA";
+  case TREND_ABOVE_LTA:
+    return "Above LTA";
+  case TREND_BELOW_LTB:
+    return "Below LTB";
+  default:
+    return "Unknown";
   }
 }
 
@@ -735,52 +815,76 @@ string CTrendLine::GetPricePositionString()
 //+------------------------------------------------------------------+
 void CTrendLine::UpdateCandleAnalysis()
 {
-  int bars=MathMin(GetBarsCount(),m_candles_lookback);
-  ArrayResize(m_candle_info,bars);
-  ArraySetAsSeries(m_candle_info,true);
-  for(int i=0;i<bars;i++)
+  int bars = MathMin(GetBarsCount(), m_candles_lookback);
+  ArrayResize(m_candle_info, bars);
+  ArraySetAsSeries(m_candle_info, true);
+  for (int i = 0; i < bars; i++)
+  {
+    double o = iOpen(m_symbol, m_timeframe, i);
+    double c = iClose(m_symbol, m_timeframe, i);
+    double h = iHigh(m_symbol, m_timeframe, i);
+    double l = iLow(m_symbol, m_timeframe, i);
+    SCandleTrendInfo info;
+    ZeroMemory(info);
+    if (IsLTAValid())
     {
-      double o=iOpen(m_symbol,m_timeframe,i);
-      double c=iClose(m_symbol,m_timeframe,i);
-      double h=iHigh(m_symbol,m_timeframe,i);
-      double l=iLow(m_symbol,m_timeframe,i);
-      SCandleTrendInfo info; ZeroMemory(info);
-      if(IsLTAValid())
-        {
-          double val=GetLineValue(i,TRENDLINE_LTA,m_lta_val);
-          info.dist_close_lta=c-val;
-          info.body_cross_lta=((o-val)*(c-val)<=0);
-          info.on_lta_upper=(o>val && c<val);
-          info.on_lta_lower=(o<val && c>val);
-          if(m_adv_features.detect_fakeout)
-            info.fakeout_lta=((h>val && c<val) || (l<val && c>val));
-        }
-      if(IsLTBValid())
-        {
-          double val=GetLineValue(i,TRENDLINE_LTB,m_ltb_val);
-          info.dist_close_ltb=c-val;
-          info.body_cross_ltb=((o-val)*(c-val)<=0);
-          info.on_ltb_upper=(o>val && c<val);
-          info.on_ltb_lower=(o<val && c>val);
-          if(m_adv_features.detect_fakeout)
-            info.fakeout_ltb=((h>val && c<val) || (l<val && c>val));
-        }
-      if(IsLTAValid() && IsLTA2Valid())
-        {
-          double v1=GetLineValue(i,TRENDLINE_LTA,m_lta_val);
-          double v2=GetLineValue(i,TRENDLINE_LTA2,m_lta2_val);
-          double upper=MathMax(v1,v2),lower=MathMin(v1,v2);
-          info.between_ltas=(o>lower && o<upper && c>lower && c<upper);
-        }
-      if(IsLTBValid() && IsLTB2Valid())
-        {
-          double v1=GetLineValue(i,TRENDLINE_LTB,m_ltb_val);
-          double v2=GetLineValue(i,TRENDLINE_LTB2,m_ltb2_val);
-          double upper=MathMax(v1,v2),lower=MathMin(v1,v2);
-          info.between_ltbs=(o>lower && o<upper && c>lower && c<upper);
-        }
-      m_candle_info[i]=info;
+      double val = GetLineValue(i, TRENDLINE_LTA, m_lta_val);
+      info.dist_close_lta = c - val;
+      info.body_cross_lta = ((o - val) * (c - val) <= 0);
+      info.on_lta_upper = (o > val && c < val);
+      info.on_lta_lower = (o < val && c > val);
+      if (m_adv_features.detect_fakeout)
+        info.fakeout_lta = ((h > val && c < val) || (l < val && c > val));
     }
+    if (IsLTBValid())
+    {
+      double val = GetLineValue(i, TRENDLINE_LTB, m_ltb_val);
+      info.dist_close_ltb = c - val;
+      info.body_cross_ltb = ((o - val) * (c - val) <= 0);
+      info.on_ltb_upper = (o > val && c < val);
+      info.on_ltb_lower = (o < val && c > val);
+      if (m_adv_features.detect_fakeout)
+        info.fakeout_ltb = ((h > val && c < val) || (l < val && c > val));
+    }
+    // Após o bloco IsLTAValid() - adicionar cálculos para LTA2
+    if (IsLTA2Valid())
+    {
+      double val = GetLineValue(i, TRENDLINE_LTA2, m_lta2_val);
+      info.dist_close_lta2 = c - val;
+      info.body_cross_lta2 = ((o - val) * (c - val) <= 0);
+      info.on_lta2_upper = (o > val && c < val);
+      info.on_lta2_lower = (o < val && c > val);
+      if (m_adv_features.detect_fakeout)
+        info.fakeout_lta2 = ((h > val && c < val) || (l < val && c > val));
+    }
+
+    // Após o bloco IsLTBValid() - adicionar cálculos para LTB2
+    if (IsLTB2Valid())
+    {
+      double val = GetLineValue(i, TRENDLINE_LTB2, m_ltb2_val);
+      info.dist_close_ltb2 = c - val;
+      info.body_cross_ltb2 = ((o - val) * (c - val) <= 0);
+      info.on_ltb2_upper = (o > val && c < val);
+      info.on_ltb2_lower = (o < val && c > val);
+      if (m_adv_features.detect_fakeout)
+        info.fakeout_ltb2 = ((h > val && c < val) || (l < val && c > val));
+    }
+    if (IsLTAValid() && IsLTA2Valid())
+    {
+      double v1 = GetLineValue(i, TRENDLINE_LTA, m_lta_val);
+      double v2 = GetLineValue(i, TRENDLINE_LTA2, m_lta2_val);
+      double upper = MathMax(v1, v2), lower = MathMin(v1, v2);
+      info.between_ltas = (o > lower && o < upper && c > lower && c < upper);
+    }
+    if (IsLTBValid() && IsLTB2Valid())
+    {
+      double v1 = GetLineValue(i, TRENDLINE_LTB, m_ltb_val);
+      double v2 = GetLineValue(i, TRENDLINE_LTB2, m_ltb2_val);
+      double upper = MathMax(v1, v2), lower = MathMin(v1, v2);
+      info.between_ltbs = (o > lower && o < upper && c > lower && c < upper);
+    }
+    m_candle_info[i] = info;
+  }
 }
 
 //+------------------------------------------------------------------+
@@ -788,32 +892,35 @@ void CTrendLine::UpdateCandleAnalysis()
 //+------------------------------------------------------------------+
 CTrendLine::SCandleTrendInfo CTrendLine::GetCandleInfo(int shift)
 {
-  if(shift<ArraySize(m_candle_info))
-     return m_candle_info[shift];
-  SCandleTrendInfo empty; ZeroMemory(empty); return empty;
+  if (shift < ArraySize(m_candle_info))
+    return m_candle_info[shift];
+  SCandleTrendInfo empty;
+  ZeroMemory(empty);
+  return empty;
 }
 
-double CTrendLine::GetDistanceToLine(int shift,ENUM_TRENDLINE_SIDE side)
+double CTrendLine::GetDistanceToLine(int shift, ENUM_TRENDLINE_SIDE side)
 {
-  if(side==TRENDLINE_LTA)
-     return GetCandleInfo(shift).dist_close_lta;
-  if(side==TRENDLINE_LTB)
-     return GetCandleInfo(shift).dist_close_ltb;
-  if(side==TRENDLINE_LTA2)
-     return GetCandleInfo(shift).dist_close_lta2;
-  if(side==TRENDLINE_LTB2)
-     return GetCandleInfo(shift).dist_close_ltb2;
+  if (side == TRENDLINE_LTA)
+    return GetCandleInfo(shift).dist_close_lta;
+  if (side == TRENDLINE_LTB)
+    return GetCandleInfo(shift).dist_close_ltb;
+  if (side == TRENDLINE_LTA2)
+    return GetCandleInfo(shift).dist_close_lta2;
+  if (side == TRENDLINE_LTB2)
+    return GetCandleInfo(shift).dist_close_ltb2;
   return 0.0;
 }
 
 CTrendLine::SCandleFullInfo CTrendLine::GetCandleFullInfo(int shift)
 {
-  SCandleFullInfo info; ZeroMemory(info);
-  info.time  = iTime(m_symbol,m_timeframe,shift);
-  info.open  = iOpen(m_symbol,m_timeframe,shift);
-  info.high  = iHigh(m_symbol,m_timeframe,shift);
-  info.low   = iLow(m_symbol,m_timeframe,shift);
-  info.close = iClose(m_symbol,m_timeframe,shift);
+  SCandleFullInfo info;
+  ZeroMemory(info);
+  info.time = iTime(m_symbol, m_timeframe, shift);
+  info.open = iOpen(m_symbol, m_timeframe, shift);
+  info.high = iHigh(m_symbol, m_timeframe, shift);
+  info.low = iLow(m_symbol, m_timeframe, shift);
+  info.close = iClose(m_symbol, m_timeframe, shift);
   info.trend = GetCandleInfo(shift);
   return info;
 }

--- a/TF_CTX/priceaction/trendline/trendline.mqh
+++ b/TF_CTX/priceaction/trendline/trendline.mqh
@@ -82,38 +82,11 @@ private:
     TrendlineContextConfig m_context_cfg;
     TrendlineAdvancedFeatures m_adv_features;
 
-    // structure to hold candle analysis information
-    struct SCandleTrendInfo
-      {
-       bool body_cross_lta;
-       bool body_cross_ltb;
-       bool between_ltas;
-       bool between_ltbs;
-       bool on_lta_upper;
-       bool on_lta_lower;
-       bool on_ltb_upper;
-       bool on_ltb_lower;
-       double dist_close_lta;
-       double dist_close_ltb;
-       double dist_close_lta2;
-       double dist_close_ltb2;
-       bool fakeout_lta;
-       bool fakeout_ltb;
-      };
+    // buffer to store candle analysis
     SCandleTrendInfo m_candle_info[];
     int              m_lta_resets;
     int              m_ltb_resets;
 
-    // Estrutura completa com dados do candle e análise de tendência
-    struct SCandleFullInfo
-      {
-       datetime time;
-       double   open;
-       double   high;
-       double   low;
-       double   close;
-       SCandleTrendInfo trend;
-      };
 
   void DrawLines(datetime t1, double p1, datetime t2, double p2,
                  ENUM_TRENDLINE_SIDE side);
@@ -138,9 +111,6 @@ private:
     double GetLineValue(int shift,ENUM_TRENDLINE_SIDE side,double current);
 
     void   UpdateCandleAnalysis();
-    SCandleTrendInfo GetCandleInfo(int shift);
-    double GetDistanceToLine(int shift,ENUM_TRENDLINE_SIDE side);
-    SCandleFullInfo  GetCandleFullInfo(int shift);
   //+------------------------------------------------------------------+
   //| Calcula o slope entre dois pontos usando índices de barra         |
   //+------------------------------------------------------------------+
@@ -152,6 +122,34 @@ private:
   }
 
 public:
+  // Informações detalhadas de candles em relação às linhas
+  struct SCandleTrendInfo
+    {
+     bool body_cross_lta;
+     bool body_cross_ltb;
+     bool between_ltas;
+     bool between_ltbs;
+     bool on_lta_upper;
+     bool on_lta_lower;
+     bool on_ltb_upper;
+     bool on_ltb_lower;
+     double dist_close_lta;
+     double dist_close_ltb;
+     double dist_close_lta2;
+     double dist_close_ltb2;
+     bool fakeout_lta;
+     bool fakeout_ltb;
+    };
+
+  struct SCandleFullInfo
+    {
+     datetime time;
+     double   open;
+     double   high;
+     double   low;
+     double   close;
+     SCandleTrendInfo trend;
+    };
   CTrendLine();
   ~CTrendLine();
 
@@ -174,6 +172,9 @@ public:
   bool IsBreakup();
   ENUM_TREND_POSITION GetPricePosition();
   string GetPricePositionString();
+  SCandleTrendInfo GetCandleInfo(int shift);
+  double GetDistanceToLine(int shift,ENUM_TRENDLINE_SIDE side);
+  SCandleFullInfo  GetCandleFullInfo(int shift);
 };
 
 //+------------------------------------------------------------------+

--- a/config.json
+++ b/config.json
@@ -100,9 +100,29 @@
                "ltb_style": "SOLID",
                "lta_width": 1,
                "ltb_width": 1,
-               "extend_right": true,
-               "min_angle": 20.0,
-               "enabled": true
+                "extend_right": true,
+                "min_angle": 20.0,
+                "trendline_candles_lookback": 9,
+                "trendline_status_flags": {
+                    "enable_body_cross": true,
+                    "enable_between_ltas": true,
+                    "enable_between_ltbs": true,
+                    "enable_distance_points": true
+                },
+                "trendline_context_analysis": {
+                    "enabled": true,
+                    "lookback": 9,
+                    "trend_threshold": 0.7,
+                    "consolidation_threshold": 0.6
+                },
+                "trendline_advanced_features": {
+                    "detect_fakeout": true,
+                    "count_touches": true,
+                    "touch_tolerance_points": 5,
+                    "status_evaluate_mode": "close_only",
+                    "register_resets": true
+                },
+                "enabled": true
             }
          ]
       },

--- a/documentation.md
+++ b/documentation.md
@@ -1127,6 +1127,9 @@ if(pa != NULL) {
     if(tl.IsBreakup()) {
         // lógica específica
     }
+    // consultar status do candle atual
+    CTrendLine::SCandleTrendInfo info = tl.GetCandleInfo(1);
+    double dist = tl.GetDistanceToLine(1, TRENDLINE_LTA);
 }
 ``` |
 | `SUPRES`         | `CSupRes`       | ```cpp
@@ -1140,4 +1143,14 @@ if(pa != NULL) {
 > **Nota:** Sempre verifique se o ponteiro retornado é `NULL` antes de realizar
 > o casting. Quando o nome não é encontrado, `GetIndicator`/`GetPriceAction`
 > retornam `NULL` e os métodos de valor retornam `0.0`.
+
+#### Novos Métodos em `CTrendLine`
+
+* `SCandleTrendInfo GetCandleInfo(int shift)` – retorna a estrutura com o
+  status do candle em relação às trendlines (cruzamento de corpo,
+  posicionamento entre linhas e fakeouts quando habilitado).
+* `double GetDistanceToLine(int shift, ENUM_TRENDLINE_SIDE side)` –
+  informa a distância em pontos até a trendline indicada.
+
+Essas análises são ativadas configurando o bloco `trendline_*` no arquivo JSON.
 


### PR DESCRIPTION
## Summary
- add trendline advanced config structures
- parse new trendline options in config manager
- extend `CTrendLine` with candle analysis methods and new members
- document new usage of `CTrendLine` methods
- update trendline JSON example
- add method to return full candle info and print candle[1]

## Testing
- `jq . config.json`


------
https://chatgpt.com/codex/tasks/task_e_686f36b6c7a0832090335145933f7305